### PR TITLE
FS-1019: Restrict test deploys to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
     needs: security
     runs-on: ubuntu-latest
     environment: test
+    if: github.ref == 'refs/heads/main' 
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Essential we do this for this repo so we don't run in branch migrations
