### PR TITLE
FS-1630: allow for UAT environment

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,7 +12,7 @@ match FLASK_ENV:
         from config.envs.test import TestConfig as Config
     case "unit_test":
         from config.envs.unit_testing import UnitTestingConfig as Config
-    case "production":
+    case "uat" | "production":
         from config.envs.production import ProductionConfig as Config
     case _:
         from config.envs.default import DefaultConfig as Config


### PR DESCRIPTION
We want to allow separate UAT and Production environments in terraform. Even if there is no config changes with production it is still useful to separate them e.g. for 
Sentry.
Note: for now config is shared with production, so no separate config file is needed
