### PR TITLE
FS-1943: Update flake8 to GitHub version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       args:
         - --line-length=79
         - --target-version=py310
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
     - id: flake8


### PR DESCRIPTION
Flake8 was migrated to GitHub around ~2 years ago, prior to that it was hosted on GitLab, so a lot of existing repositories still point to that.  The maintainers kept getting issues posted on GitLab even after freezing the repository, so out of their own interest have made the repository private (yesterday) to force people to update to the new maintained version on GitHub.