### PR TITLE
FS-2045: fix manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,8 +13,6 @@ applications:
   health-check-type: http
   services:
     - assessment-store-dev-db
----
-applications:
 - name: funding-service-design-assessment-store-test
   memory: 128M
   buildpacks:


### PR DESCRIPTION
theory is that having 2 applications keys was causing the manifest to be interpreted in a weird way and databases being bound incorrectly