### PR TITLE
FS-2040: add application store host

### DIFF
--- a/scripts/import_from_application.py
+++ b/scripts/import_from_application.py
@@ -5,6 +5,7 @@ import requests
 from app import app
 from config import Config
 from db.queries import bulk_insert_application_record
+from fsd_utils import CommonConfig
 
 parser = argparse.ArgumentParser(
     description="Import applcations from application store."
@@ -16,7 +17,7 @@ args = parser.parse_args()
 with app.app_context():
 
     applications_url = (
-        Config.APPLICATIONS_ENDPOINT
+        CommonConfig.APPLICATION_STORE_API_HOST + Config.APPLICATIONS_ENDPOINT
         + "?status_only=SUBMITTED"
         + f"&round_id={args.roundid}"
     )


### PR DESCRIPTION
Script was failing previously as the application store host was not specified i.e.

```
requests.exceptions.MissingSchema: Invalid URL '/applications?status_only=SUBMITTED&round_id=c603d114-5364-4474-a0c4-c41cbf4d3bbd': No scheme supplied. Perhaps you meant http:///applications?status_only=SUBMITTED&round_id=c603d114-5364-4474-a0c4-c41cbf4d3bbd?
```