### PR TITLE
FS-2040: add forms parameter to query string

### DIFF
--- a/scripts/import_from_application.py
+++ b/scripts/import_from_application.py
@@ -20,6 +20,7 @@ with app.app_context():
         CommonConfig.APPLICATION_STORE_API_HOST + Config.APPLICATIONS_ENDPOINT
         + "?status_only=SUBMITTED"
         + f"&round_id={args.roundid}"
+        + "&forms=true"
     )
 
     app_store_response_json = requests.get(applications_url).json()


### PR DESCRIPTION
The import script was failing as it was missing the `forms` query parameter e.g.

```
   2023-01-05T13:57:13.65+0000 [APP/TASK/import/0] ERR File "/home/vcap/app/scripts/import_from_application.py", line 29, in <module>
   2023-01-05T13:57:13.65+0000 [APP/TASK/import/0] ERR form_jsons_list = application["forms"]
   2023-01-05T13:57:13.65+0000 [APP/TASK/import/0] ERR KeyError: 'forms'
```