### PR TITLE
FS-2146: Fix latest sub criteria score query

### DIFF
--- a/db/queries/scores/queries.py
+++ b/db/queries/scores/queries.py
@@ -23,25 +23,18 @@ def get_scores_for_app_sub_crit(
     :param score_history: Boolean value that reurns all scores if true
     :return: dictionary.
     """
-    if score_history:
-        stmt = (
-            select(Score)
-            .where(
-                Score.application_id == application_id,
-                Score.sub_criteria_id == sub_criteria_id,
-            )
-            .order_by(Score.date_created.desc())
+
+    stmt = (
+        select(Score)
+        .where(
+            Score.application_id == application_id,
+            Score.sub_criteria_id == sub_criteria_id,
         )
-    else:
-        stmt = (
-            select(Score)
-            .where(
-                Score.application_id == application_id,
-                Score.sub_criteria_id == sub_criteria_id,
-            )
-            .order_by(Score.date_created.desc())
-            .limit(1)
-        )
+        .order_by(Score.date_created.desc())
+    )
+
+    if not score_history:
+        stmt = stmt.limit(1)
 
     score_rows = db.session.scalars(stmt)
 


### PR DESCRIPTION
- Fix latest sub criteria score query limit
- Add test to verify changes function as intended

Previously, we were limiting to `1` - which was only returning a single score for the entire application id.
What we actually want, is the latest score for every unique sub criteria id in an assessment record.
