### PR TITLE
FS-2188: Change to use rsplit with limit of 1

### DIFF
--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -129,7 +129,8 @@ def sort_add_another_component_contents(
                         and theme["presentation_type"] == "amount"
                     ):
                         amount_answer = [
-                            amount.split(": ")[1] for amount in theme["answer"]
+                            amount.rsplit(": ", 1)[1]
+                            for amount in theme["answer"]
                         ]
 
                         theme["answer"] = amount_answer

--- a/tests/test_get_sub_criteria.py
+++ b/tests/test_get_sub_criteria.py
@@ -20,6 +20,11 @@ from api.routes.subcriterias.get_sub_criteria import (
             ["£1"],
         ),
         (
+            ["An : Answer : with : lots: of :colons : £1"],
+            ["An : Answer : with : lots: of :colons "],
+            ["£1"],
+        ),
+        (
             ["An Answer : £1", "Another Answer : £2"],
             ["An Answer ", "Another Answer "],
             ["£1", "£2"],

--- a/tests/test_get_sub_criteria.py
+++ b/tests/test_get_sub_criteria.py
@@ -1,11 +1,36 @@
 from unittest.mock import Mock
 
+import pytest
 from api.routes.subcriterias.get_sub_criteria import (
     sort_add_another_component_contents,
 )
 
 
-def test_sort_add_another_component_contents():
+@pytest.mark.parametrize(
+    "answer_from_form_runner, expected_description, expected_amount",
+    [
+        (
+            ["An Answer : £1"],
+            ["An Answer "],
+            ["£1"],
+        ),
+        (
+            ["An Answer : with colon : £1"],
+            ["An Answer : with colon "],
+            ["£1"],
+        ),
+        (
+            ["An Answer : £1", "Another Answer : £2"],
+            ["An Answer ", "Another Answer "],
+            ["£1", "£2"],
+        ),
+    ],
+)
+def test_sort_add_another_component_contents(
+    answer_from_form_runner,
+    expected_description,
+    expected_amount,
+):
     themes_answers = [
         {
             "presentation_type": "heading",
@@ -17,21 +42,21 @@ def test_sort_add_another_component_contents():
             "presentation_type": "description",
             "question": "Test Description",
             "field_id": "123",
-            "answer": ["Test Description: Test"],
+            "answer": answer_from_form_runner,
         },
         {
             "presentation_type": "amount",
             "question": "Test Amount",
             "field_id": "123",
-            "answer": ["Test Amount: 100"],
+            "answer": answer_from_form_runner,
         },
     ]
 
     sort_add_another_component_contents(themes_answers)
 
     assert themes_answers[0]["answer"] == "Test Heading"
-    assert themes_answers[1]["answer"] == ["Test Description"]
-    assert themes_answers[2]["answer"] == ["100"]
+    assert themes_answers[1]["answer"] == expected_description
+    assert themes_answers[2]["answer"] == expected_amount
 
 
 def test_sort_add_another_component_contents_log_when_no_answer(monkeypatch):


### PR DESCRIPTION
We're splitting on `: ` from the left, without any limit.  The user has entered a `:`  as part of their description, so we're splitting pre-maturely and incorrectly, which subsequently messes up the float coercion on the frontend. Changing to `rsplit` with a limit of `1`, should fix the immediate issue.

Relevant links (for reference):
- https://github.com/communitiesuk/funding-service-design-assessment-store/pull/58#discussion_r1047347313
- [slack thread](https://communities-govuk.slack.com/archives/C02PHBER287/p1673882389522519)
- [JIRA FS-2188](https://digital.dclg.gov.uk/jira/browse/FS-2188)
