### PR TITLE
FS-2289 - Fixed metric issue, now uses retrieve flags endpoint

### DIFF
--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -14,6 +14,7 @@ from db.queries import get_metadata_for_fund_round_id
 from db.queries import retrieve_flags_for_applications
 from db.queries.assessment_records.queries import find_assessor_task_list_state, update_status_to_completed
 from db.queries.flags.queries import get_latest_flags_for_each
+from db.queries.flags.queries import find_qa_complete_flag_for_applications
 from db.queries.assessment_records.queries import find_assessor_task_list_state
 from db.queries.assessment_records.queries import ( 
     get_assessment_sub_critera_state,
@@ -141,14 +142,13 @@ def assessment_stats_for_fund_round_id(
     stats = {}
     assessments = get_metadata_for_fund_round_id(
         fund_id=fund_id, round_id=round_id
-    )
+    )s
     assessment_ids = [application['application_id'] for application in assessments ]
 
-    qa_completed_assessments = [
+    qa_completed_assessments = [    
         flag["application_id"]
-        for flag in retrieve_flags_for_applications(assessment_ids)
-    ]
-    
+        for flag in find_qa_complete_flag_for_applications(assessment_ids)
+    ]    
     stopped_assessments = [
         flag["application_id"] for flag in get_latest_flags_for_each("STOPPED")
     ]

--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -142,7 +142,7 @@ def assessment_stats_for_fund_round_id(
     stats = {}
     assessments = get_metadata_for_fund_round_id(
         fund_id=fund_id, round_id=round_id
-    )s
+    )
     assessment_ids = [application['application_id'] for application in assessments ]
 
     qa_completed_assessments = [    

--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -11,6 +11,7 @@ from api.routes.subcriterias.get_sub_criteria import (
     return_subcriteria_from_mapping,
 )
 from db.queries import get_metadata_for_fund_round_id
+from db.queries import retrieve_flags_for_applications
 from db.queries.assessment_records.queries import find_assessor_task_list_state, update_status_to_completed
 from db.queries.flags.queries import get_latest_flags_for_each
 from db.queries.assessment_records.queries import find_assessor_task_list_state
@@ -141,10 +142,13 @@ def assessment_stats_for_fund_round_id(
     assessments = get_metadata_for_fund_round_id(
         fund_id=fund_id, round_id=round_id
     )
+    assessment_ids = [application['application_id'] for application in assessments ]
+
     qa_completed_assessments = [
         flag["application_id"]
-        for flag in get_latest_flags_for_each("QA_COMPLETED")
+        for flag in retrieve_flags_for_applications(assessment_ids)
     ]
+    
     stopped_assessments = [
         flag["application_id"] for flag in get_latest_flags_for_each("STOPPED")
     ]

--- a/db/queries/__init__.py
+++ b/db/queries/__init__.py
@@ -6,6 +6,7 @@ from .comments.queries import get_comments_for_application_sub_crit
 from .flags.queries import create_flag_for_application
 from .flags.queries import retrieve_flag_for_application
 from .flags.queries import retrieve_flags_for_applications
+from .flags.queries import find_qa_complete_flag_for_applications
 from .progress.queries import get_progress_for_app
 from .scores.queries import create_score_for_app_sub_crit
 from .scores.queries import get_scores_for_app_sub_crit
@@ -22,4 +23,5 @@ __all__ = [
     "retrieve_flags_for_applications",
     "create_flag_for_application",
     "get_progress_for_app",
+    "find_qa_complete_flag_for_applications",
 ]

--- a/db/queries/flags/queries.py
+++ b/db/queries/flags/queries.py
@@ -58,6 +58,18 @@ def find_qa_complete_flag(application_id):
 
     return {"is_qa_complete": bool(qa_complete_flag)}
 
+def find_qa_complete_flag_for_applications(application_ids: list[str]) -> dict:
+    flags = (
+        Flag.query.filter(Flag.application_id.in_(application_ids),
+        Flag.flag_type == "QA_COMPLETED")
+        .all()
+    )
+
+    metadata_serialiser = FlagMetadata()
+    flag_metadatas = [metadata_serialiser.dump(flag) for flag in flags]
+
+    return flag_metadatas
+
 
 def retrieve_flags_for_applications(application_ids: list[str]) -> dict:
     flags = (

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -422,8 +422,8 @@ def test_find_qa_complete_flag_for_applications(db_session):
     first_application_flagged_flag = Flag(**flag_config[2])
     db_session.add(first_application_flagged_flag)
     
-    first_application_flagged_qa_complete_flag = Flag(**flag_config[3])
-    db_session.add(first_application_flagged_qa_complete_flag)
+    first_application_qa_complete_flag = Flag(**flag_config[3])
+    db_session.add(first_application__qa_complete_flag)
     
     second_application_qa_complete_flag = Flag(**flag_config[4])
     db_session.add(second_application_qa_complete_flag)

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -445,10 +445,6 @@ def test_find_qa_complete_flag_for_applications(db_session):
     assert result[1]['flag_type'] == second_application_qa_complete_flag.flag_type.name
     assert len(result) == 2
 
-    import sys
-    sys.stdout.write("{}".format(result))
-
-
 def test_get_latest_flags_for_each(sample_flags):
     result_list = get_latest_flags_for_each()
 

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -419,21 +419,34 @@ def test_find_qa_complete_flag_for_applications(db_session):
     """Put QA_COMPLETED flags in 1 out of 2 applications and
     only retrieve the metadata for the 1 with QA_COMPLETED"""
 
-    first_flag = Flag(**flag_config[2])
-    db_session.add(first_flag)
-    second_flag = Flag(**flag_config[3])
+    first_application_flagged_flag = Flag(**flag_config[2])
+    db_session.add(first_application_flagged_flag)
+    
+    first_application_flagged_qa_complete_flag = Flag(**flag_config[3])
+    db_session.add(first_application_flagged_qa_complete_flag)
+    
+    second_application_qa_complete_flag = Flag(**flag_config[4])
+    db_session.add(second_application_qa_complete_flag)
 
-    db_session.add(second_flag)
-    third_flag = Flag(**flag_config[0])
-    db_session.add(third_flag)
+    third_application_flagged_flag = Flag(**flag_config[0])
+    db_session.add(third_application_flagged_flag)
 
     db_session.commit()
 
-    result = find_qa_complete_flag_for_applications([first_flag.application_id, third_flag.application_id])
+    result = find_qa_complete_flag_for_applications([
+        first_application_flagged_flag.application_id, 
+        second_application_qa_complete_flag.application_id,
+        third_application_flagged_flag.application_id
+        ])
 
-    assert result[0]['application_id'] == first_flag.application_id
-    assert result[0]['flag_type'] == first_flag.flag_type.name
-    assert len(result) == 1
+    assert result[0]['application_id'] == first_application_flagged_flag.application_id
+    assert result[0]['flag_type'] == first_application_flagged_flag.flag_type.name
+    assert result[1]['application_id'] == second_application_qa_complete_flag.application_id
+    assert result[1]['flag_type'] == second_application_qa_complete_flag.flag_type.name
+    assert len(result) == 2
+
+    import sys
+    sys.stdout.write("{}".format(result))
 
 
 def test_get_latest_flags_for_each(sample_flags):

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -15,6 +15,7 @@ from db.models.comment.enums import CommentType
 from db.queries import create_flag_for_application
 from db.queries import find_answer_by_key_runner
 from db.queries import retrieve_flag_for_application
+from db.queries import find_qa_complete_flag_for_applications
 from db.queries.assessment_records.queries import (
     bulk_update_location_jsonb_blob,
 )
@@ -413,6 +414,26 @@ def test_retrieve_flag_for_application(db_session):
     assert result["application_id"] == second_flag.application_id
     assert result["user_id"] == second_flag.user_id
     assert result["flag_type"] == second_flag.flag_type.name
+
+def test_find_qa_complete_flag_for_applications(db_session):
+    """Put QA_COMPLETED flags in 1 out of 2 applications and
+    only retrieve the metadata for the 1 with QA_COMPLETED"""
+
+    first_flag = Flag(**flag_config[2])
+    db_session.add(first_flag)
+    second_flag = Flag(**flag_config[3])
+
+    db_session.add(second_flag)
+    third_flag = Flag(**flag_config[0])
+    db_session.add(third_flag)
+
+    db_session.commit()
+
+    result = find_qa_complete_flag_for_applications([first_flag.application_id, third_flag.application_id])
+
+    assert result[0]['application_id'] == first_flag.application_id
+    assert result[0]['flag_type'] == first_flag.flag_type.name
+    assert len(result) == 1
 
 
 def test_get_latest_flags_for_each(sample_flags):

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -416,14 +416,14 @@ def test_retrieve_flag_for_application(db_session):
     assert result["flag_type"] == second_flag.flag_type.name
 
 def test_find_qa_complete_flag_for_applications(db_session):
-    """Put QA_COMPLETED flags in 1 out of 2 applications and
+    """Put QA_COMPLETED flags in 2 out of 3 applications and
     only retrieve the metadata for the 1 with QA_COMPLETED"""
 
     first_application_flagged_flag = Flag(**flag_config[2])
     db_session.add(first_application_flagged_flag)
     
     first_application_qa_complete_flag = Flag(**flag_config[3])
-    db_session.add(first_application__qa_complete_flag)
+    db_session.add(first_application_qa_complete_flag)
     
     second_application_qa_complete_flag = Flag(**flag_config[4])
     db_session.add(second_application_qa_complete_flag)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -279,3 +279,30 @@ def test_get_assessments_stats(client):
     ).json
 
     assert response_json == ASSESSMENTS_STATS_RESPONSE
+
+    # Test number of QA_COMPLETE Applications is correct
+    # Add one more QA_COMPLETE flag to another application
+    # and also FLAGGED so we can see that the most recent flag does not interfere
+    # "qa_completed" should return 2
+
+    create_flag_for_application(
+        justification="QA Complete Test 1",
+        section_to_flag="Overview",
+        application_id=applications[1]["application_id"],
+        user_id="abc",
+        flag_type=FlagType.QA_COMPLETED,
+    )
+
+    create_flag_for_application(
+        justification="QA Complete Test 1",
+        section_to_flag="Overview",
+        application_id=applications[1]["application_id"],
+        user_id="abc",
+        flag_type=FlagType.FLAGGED,
+    )
+
+    response_json = client.get(
+        f"/assessments/get-stats/{fund_id}/{round_id}"
+    ).json
+
+    assert response_json['qa_completed'] == 2    


### PR DESCRIPTION
### Issue:
The reason for the inaccurate metric is because the endpoint retrieving the applications data retrieves the following metrics for example: 

{'assessing': 0, 'completed': 3, 'flagged': 0, 'not_started': 7, 'qa_completed': 3, 'stopped': 0, 'total': 10}
 
At this point the metric will show 3 QA Completed, however, if we now FLAG an application, although it is still QA completed, since the latest flag is "Flagged", the following will show:

{'assessing': 0, 'completed': 3, 'flagged': 1, 'not_started': 7, 'qa_completed': 2, 'stopped': 0, 'total': 10}

The reason for this is because the endpoint retrieving 'qa_completed' will only count it as true if that is the latest flag. 

### Fix:

The query used to retrieve the amount of qa_completed applications previously only returned true IF qa_completed was the latest flag. I have changed this to use the new query find_qa_complete_flags_for_applications query which searches for those applications which have a qa completed flag in them