### PR TITLE
FS-2294: return all comments if theme_id not supplied

### DIFF
--- a/db/queries/comments/queries.py
+++ b/db/queries/comments/queries.py
@@ -19,9 +19,14 @@ def get_comments_for_application_sub_crit(
     sub_criteria_id.
     :param application_id: The stringified application UUID.
     :param sub_criteria_id: The stringified sub_criteria UUID.
+    :param theme_id: optional theme_id, if not supplied
+    returns all comments for subcriteria
     :return: dictionary.
     """
-    if theme_id == "score":
+    # TODO: remove 'score' option once
+    # frontend updated not to use it as it is not
+    # semantically meaningful
+    if not theme_id or theme_id == "score":
         stmt = (
             select(Comment)
             .where(

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -260,13 +260,24 @@ def test_get_comments():
         application_id, sub_criteria_id, theme_id
     )
     comment_metadata = get_comments_for_application_sub_crit(
-        application_id, sub_criteria_id, theme_id="score"
+        application_id, sub_criteria_id, theme_id=None
     )
 
     assert len(comment_metadata_for_theme) == 2
     assert (
         comment_metadata_for_theme[0]["theme_id"]
         == comment_metadata_for_theme[1]["theme_id"]
+    )
+    assert len(comment_metadata) == 3
+    # TODO: remove this once frontend is updated not to use 'theme_id=score'
+    comment_metadata_score_theme_id = get_comments_for_application_sub_crit(
+        application_id, sub_criteria_id, theme_id="score"
+    )
+
+    assert len(comment_metadata_for_theme) == 2
+    assert (
+        comment_metadata_score_theme_id[0]["theme_id"]
+        == comment_metadata_score_theme_id[1]["theme_id"]
     )
     assert len(comment_metadata) == 3
 


### PR DESCRIPTION
Previously we returned all comments only if a parameter of `theme_id=score` was supplied.

This is not semantically meaningful and was presumably done to match the similarly confusing behaviour in the frontend.

This changes the behaviour to return all comments for a subcriteria if no theme is supplied. It maintains the old behaviour for backwards compatibility until the frontend is deployed without using `theme_id=score`