### PR TITLE
changing utils imports

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,10 +15,6 @@ async-timeout==4.0.2
     # via
     #   -r requirements.txt
     #   redis
-async-timeout==4.0.2
-    # via
-    #   -r requirements.txt
-    #   redis
 attrs==22.1.0
     # via
     #   -r requirements.txt
@@ -143,7 +139,7 @@ flupy==1.2.0
     # via
     #   -r requirements.txt
     #   alembic-utils
-funding-service-design-utils==1.0.26
+funding-service-design-utils==1.0.27
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #-----------------------------------
 #   FSD Utils
 #-----------------------------------
-funding-service-design-utils>=1.0.26,<1.1.0
+funding-service-design-utils>=1.0.27,<1.1.0
 
 requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ alembic-utils==0.7.8
     # via -r requirements.in
 async-timeout==4.0.2
     # via redis
-async-timeout==4.0.2
-    # via redis
 attrs==22.1.0
     # via jsonschema
 babel==2.11.0
@@ -81,7 +79,7 @@ flipper-client==1.3.1
     # via funding-service-design-utils
 flupy==1.2.0
     # via alembic-utils
-funding-service-design-utils==1.0.26
+funding-service-design-utils==1.0.27
     # via -r requirements.in
 gunicorn==20.1.0
     # via funding-service-design-utils
@@ -197,17 +195,12 @@ requests==2.28.2
     #   funding-service-design-utils
     #   prance
     #   python-consul
-    #   python-consul
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==12.6.0
     # via funding-service-design-utils
 ruamel-yaml==0.17.21
     # via prance
-ruamel-yaml-clib==0.2.7
-    # via ruamel-yaml
-s3transfer==0.6.0
-    # via boto3
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from tests._sql_infos import attach_listeners
 
 # Loads the fixtures in this module in utils to create and
 # clear the unit test DB
-pytest_plugins = ["fsd_utils.fixtures.db_fixtures"]
+pytest_plugins = ["fsd_test_utils.fixtures.db_fixtures"]
 with open("tests/test_data/hand-crafted-apps.json", "r") as f:
     test_input_data = json.load(f)
 


### PR DESCRIPTION
Fixing app crashes on test because the new utils package was requiring pytest at runtime. This PR brings in a new version of utils that fixes that, and updates the package name accordingly.


- [ n/a] Unit tests and other appropriate tests added or updated
- [ n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

1. Install dependenices
2. Remove pytest using `pip uninstall pytest`
3. Run app using `flask run`, app should start without import errors


### Screenshots of UI changes (if applicable)
n/a