### PR TITLE
Remove the [if y] text from the heading as some users may not underst…

### DIFF
--- a/config/mappings/mapping_parts/scored_criteria.py
+++ b/config/mappings/mapping_parts/scored_criteria.py
@@ -95,7 +95,7 @@ scored_criteria = [
                                 "form_name": "community-engagement",
                                 "field_type": "multilineTextField",
                                 "presentation_type": "text",
-                                "question": "[if y] Describe your fundraising activities",
+                                "question": "Describe your fundraising activities",
                                 # Determined by Yes-No JCACTy
                             },
                         ],


### PR DESCRIPTION
Accessibility - Non-descriptive heading (Medium priority)
[FS-2323](https://digital.dclg.gov.uk/jira/browse/FS-2323)

### Change description

The ‘[if y] Describe your fundraising activities’ heading is non-descriptive, and users may not understand what the ‘[if y]’ part of the description is related to on the page.
![image](https://user-images.githubusercontent.com/95699325/229489586-41dbc38f-a49e-406a-82ca-9b36e8954dad.png)

Solution: Remove the [if y] text from the heading as some users may not understand the purpose of the heading as a result. Flow is still intact.
![image](https://user-images.githubusercontent.com/95699325/229489922-d21b854a-927e-447a-a31c-39484b5c39e2.png)

