### PR TITLE
Fix - chunk postcode.io data and add detail to location script logging

### DIFF
--- a/scripts/location_utils.py
+++ b/scripts/location_utils.py
@@ -117,7 +117,7 @@ def extract_location_data(json_data_item):
         result = {postcode: {"error": True}}
     return result
 
-    
+
 def get_all_location_data(just_postcodes) -> dict:
     """
     Takes in a list of postcodes then uses the functions above to retrieve
@@ -127,9 +127,12 @@ def get_all_location_data(just_postcodes) -> dict:
     # postcode.io API postcode query limit
     print(f"Getting address information for {len(just_postcodes)} postcodes.")
     max_len = 99
-    just_postcodes_sub_lists = [just_postcodes[i:i+max_len] for i in range(0, len(just_postcodes), max_len)]
+    just_postcodes_sub_lists = [
+        just_postcodes[i : i + max_len]
+        for i in range(0, len(just_postcodes), max_len)
+    ]
 
-    postcode_result_chunks = [] 
+    postcode_result_chunks = []
     for sub_list in just_postcodes_sub_lists:
         raw_location_data = retrieve_data_from_postcodes_io(sub_list)
         postcode_result_chunks.append(raw_location_data)
@@ -139,7 +142,9 @@ def get_all_location_data(just_postcodes) -> dict:
         for postcode_data_item in raw_location_data.json()["result"]:
             postcode = postcode_data_item["query"]
             location_data = extract_location_data(postcode_data_item)
-            print(f"There was a problem extracting address information for postcode: {postcode}.") if location_data[postcode]["error"] else None
+            print(
+                f"There was a problem extracting address information for postcode: {postcode}."
+            ) if location_data[postcode]["error"] else None
             postcodes_to_location_data[postcode] = location_data[postcode]
 
     return postcodes_to_location_data
@@ -159,7 +164,9 @@ def update_db_with_location_data(
         }
         for application_id, postcode in application_ids_to_postcodes.items()
     ]
-    print("Updating assessment records with postcode matched address information.")
+    print(
+        "Updating assessment records with postcode matched address information."
+    )
     bulk_update_location_jsonb_blob(application_ids_to_location_data)
 
 

--- a/scripts/location_utils.py
+++ b/scripts/location_utils.py
@@ -128,7 +128,7 @@ def get_all_location_data(just_postcodes) -> dict:
     print(f"Getting address information for {len(just_postcodes)} postcodes.")
     max_len = 99
     just_postcodes_sub_lists = [
-        just_postcodes[i : i + max_len]
+        just_postcodes[i : i + max_len]  # noqa
         for i in range(0, len(just_postcodes), max_len)
     ]
 
@@ -138,15 +138,21 @@ def get_all_location_data(just_postcodes) -> dict:
         postcode_result_chunks.append(raw_location_data)
 
     postcodes_to_location_data = {}
+    fail_count = 0
     for raw_location_data in postcode_result_chunks:
         for postcode_data_item in raw_location_data.json()["result"]:
             postcode = postcode_data_item["query"]
             location_data = extract_location_data(postcode_data_item)
-            print(
-                f"There was a problem extracting address information for postcode: {postcode}."
-            ) if location_data[postcode]["error"] else None
+            if location_data[postcode]["error"]:
+                print(
+                    "There was a problem extracting address"
+                    f" information for postcode: {postcode}."
+                )
+                fail_count += 1
             postcodes_to_location_data[postcode] = location_data[postcode]
-
+    print(
+        f"Failed to retrieve address information for {fail_count} postcodes."
+    )
     return postcodes_to_location_data
 
 
@@ -165,7 +171,8 @@ def update_db_with_location_data(
         for application_id, postcode in application_ids_to_postcodes.items()
     ]
     print(
-        "Updating assessment records with postcode matched address information."
+        "Updating assessment records with postcode matched address"
+        " information."
     )
     bulk_update_location_jsonb_blob(application_ids_to_location_data)
 

--- a/scripts/location_utils.py
+++ b/scripts/location_utils.py
@@ -117,20 +117,30 @@ def extract_location_data(json_data_item):
         result = {postcode: {"error": True}}
     return result
 
-
+    
 def get_all_location_data(just_postcodes) -> dict:
     """
     Takes in a list of postcodes then uses the functions above to retrieve
     location data for each one, and returns a map of postcodes to location
     details
     """
-    raw_location_data = retrieve_data_from_postcodes_io(just_postcodes)
-    postcodes_to_location_data = {}
+    # postcode.io API postcode query limit
+    print(f"Getting address information for {len(just_postcodes)} postcodes.")
+    max_len = 99
+    just_postcodes_sub_lists = [just_postcodes[i:i+max_len] for i in range(0, len(just_postcodes), max_len)]
 
-    for postcode_data_item in raw_location_data.json()["result"]:
-        postcode = postcode_data_item["query"]
-        location_data = extract_location_data(postcode_data_item)
-        postcodes_to_location_data[postcode] = location_data[postcode]
+    postcode_result_chunks = [] 
+    for sub_list in just_postcodes_sub_lists:
+        raw_location_data = retrieve_data_from_postcodes_io(sub_list)
+        postcode_result_chunks.append(raw_location_data)
+
+    postcodes_to_location_data = {}
+    for raw_location_data in postcode_result_chunks:
+        for postcode_data_item in raw_location_data.json()["result"]:
+            postcode = postcode_data_item["query"]
+            location_data = extract_location_data(postcode_data_item)
+            print(f"There was a problem extracting address information for postcode: {postcode}.") if location_data[postcode]["error"] else None
+            postcodes_to_location_data[postcode] = location_data[postcode]
 
     return postcodes_to_location_data
 
@@ -149,6 +159,7 @@ def update_db_with_location_data(
         }
         for application_id, postcode in application_ids_to_postcodes.items()
     ]
+    print("Updating assessment records with postcode matched address information.")
     bulk_update_location_jsonb_blob(application_ids_to_location_data)
 
 

--- a/scripts/populate_location_data.py
+++ b/scripts/populate_location_data.py
@@ -37,7 +37,9 @@ def process_locations(
         application_ids_to_postcodes = {}
 
         # extract the postcode from each application we have
-        print(f"Extracting postcodes from {len(application_ids)} applications for fund_id: {fund_id}, round_id: {round_id}")
+        print(
+            f"Extracting postcodes from {len(application_ids)} applications for fund_id: {fund_id}, round_id: {round_id}"
+        )
         for id in application_ids:
             app_json = get_application_jsonb_blob(id[0])
             questions = get_application_form(app_json)

--- a/scripts/populate_location_data.py
+++ b/scripts/populate_location_data.py
@@ -38,7 +38,8 @@ def process_locations(
 
         # extract the postcode from each application we have
         print(
-            f"Extracting postcodes from {len(application_ids)} applications for fund_id: {fund_id}, round_id: {round_id}"
+            f"Extracting postcodes from {len(application_ids)}"
+            f" applications for fund_id: {fund_id}, round_id: {round_id}"
         )
         for id in application_ids:
             app_json = get_application_jsonb_blob(id[0])

--- a/scripts/populate_location_data.py
+++ b/scripts/populate_location_data.py
@@ -37,6 +37,7 @@ def process_locations(
         application_ids_to_postcodes = {}
 
         # extract the postcode from each application we have
+        print(f"Extracting postcodes from {len(application_ids)} applications for fund_id: {fund_id}, round_id: {round_id}")
         for id in application_ids:
             app_json = get_application_jsonb_blob(id[0])
             questions = get_application_form(app_json)
@@ -46,7 +47,6 @@ def process_locations(
         postcodes_to_location_data = get_all_location_data(just_postcodes)
 
         if update_db:
-            print("Updating db")
             update_db_with_location_data(
                 application_ids_to_postcodes, postcodes_to_location_data
             )


### PR DESCRIPTION
Part of: https://digital.dclg.gov.uk/jira/browse/FS-2468

A fix to the 'populate_location_data.py' script. The new round has a number of applications over the api limit for postode.io. This fix chunks queries to the postcode api to remain below the limit.

I also took the opportunity to add some useful logging.