### PR TITLE
update seed data and add a patch fix

### DIFF
--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -107,23 +107,25 @@ def sort_add_another_component_contents(
     in array of themes fields, if exists, adds question-value
     to an answer key for presentation_type "heading" theme and
     looks for presentation_type of "description" and "amount" with
-    same presentation_type "heading"s field_id, retrieve words only
-    from strings of answers for presentation_type "description" theme
-    & numbers only for presentation_type "amount" theme.
+    same presentation_type "heading"s field_id, retrieve words
+    onlyproject-costs from strings of answers for
+    presentation_type "description" theme& numbers only
+    for presentation_type "amount" theme.
 
     Args:
         themes_answers (_type_): array of dict
     """
-    for heading in themes_fields:
+    for field in themes_fields:
         try:
-            if heading["presentation_type"] == "heading":
+            if field["presentation_type"] == "heading":
                 current_app.logger.info(
                     "mapping add-another component contents"
                 )
-                heading["answer"] = heading["question"]
+                field["answer"] = field["question"]
+                # match each add-another answer
                 for theme in themes_fields:
                     if (
-                        heading["field_id"] in theme.values()
+                        field["field_id"] in theme.values()
                         and theme["presentation_type"] == "description"
                     ):
                         description_answer = [
@@ -133,7 +135,7 @@ def sort_add_another_component_contents(
                         theme["answer"] = description_answer
 
                     if (
-                        heading["field_id"] in theme.values()
+                        field["field_id"] in theme.values()
                         and theme["presentation_type"] == "amount"
                     ):
                         amount_answer = [
@@ -148,7 +150,7 @@ def sort_add_another_component_contents(
 
         except (KeyError, IndexError):
             current_app.logger.debug(
-                f"Answer not provided for field_id: {heading['field_id']}"
+                f"Answer not provided for field_id: {field['field_id']}"
             )
 
 
@@ -179,7 +181,20 @@ def map_single_field_answer(theme: list, questions: dict) -> str:
                 theme["field_id"] == app_fields["key"]
                 and "answer" in app_fields.keys()
             ):
-                theme["answer"] = app_fields["answer"]
+                # TODO: Refactor this work-around for the
+                # temporary state of the add-another component
+                # we check if this is of type "add-another"
+                # and convert into a consumable format
+                if (
+                    isinstance(app_fields["answer"], list)
+                    and "type-of-revenue-cost" in app_fields["answer"][0]
+                ):
+                    theme["answer"] = [
+                        f"{item['type-of-revenue-cost']} : £{item['value']}"
+                        for item in app_fields["answer"]
+                    ]
+                else:
+                    theme["answer"] = app_fields["answer"]
 
 
 def map_application_with_sub_criteria_themes(

--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -100,7 +100,9 @@ def convert_boolean_values(themes_fields: list[dict]) -> list[dict]:
                 continue
 
 
-def sort_add_another_component_contents(
+# supports the olf version of add-another which was
+# not scalable and did not allow the adding of N* fields
+def deprecated_sort_add_another_component_contents(
     themes_fields: list[dict],
 ) -> list[dict]:
     """function checks for special presentation_type "heading"
@@ -223,6 +225,10 @@ def map_application_with_sub_criteria_themes(
             return f"Incorrect theme id -> {theme_id}"
 
     convert_boolean_values(themes_fields)
-    sort_add_another_component_contents(themes_fields)
+    # Does not sort on the new version of add-another
+    # simply pass the object through for display by assessment frontend
+    # the old version of add-another which was not scalable and
+    # did not allow the adding of N* fields
+    deprecated_sort_add_another_component_contents(themes_fields)
     current_app.logger.info("Successfully mapped subcriteria theme contents")
     return themes_fields

--- a/current_thinking.txt
+++ b/current_thinking.txt
@@ -1,0 +1,68 @@
+# flake8: noqa
+Title: Your funding
+
+[
+"Town Funding : £52375340",
+"City Funding : £412345"
+]
+
+Currently assessment reads this as:
+Title = Your funding
+["DESCRIPTION: VALUE]
+
+In new structure translates to:
+[ {
+"Source": "Town Funding",
+"Value": "£52375340",
+},
+{
+"Source": "City Funding",
+"Value": "£412345",
+},]
+We get additional info (field title as key)
+
+
+---
+E.G: If we had 3 inputs in the add-another
+
+In old format this would be: [
+"Test Data 1 : Test Data 1 : Test Data 1",
+"Test Data 2 : Test Data 2 : Test Data 2",
+"Test Data 3 : Test Data 3 : Test Data 3"
+]
+
+WE CAN NO LONGER READ AS ["DESCRIPTION: VALUE] because we could have N* inputs in the add-another
+
+[ {
+"Example input 1": "Test Data 1",
+"Example input 2": "Test Data 1",
+"Example input 3": "Test Data 1"
+},
+{
+"Example input 1": "Test Data 2",
+"Example input 2": "Test Data 2",
+"Example input 3": "Test Data 2"
+},
+{
+"Example input 1": "Test Data 3",
+"Example input 2": "Test Data 3",
+"Example input 3": "Test Data 3"
+}]
+
+Instead we should just pass it all into assessment. Then assessment can read the dict to display.
+
+E.g:
+Then the dict key is the heading and value the row value under the heading
+
+
+MULTI-INPUT-FIELD TITLE
+
+Example Input 1 | Example Input 2 | Example Input 3
+-----------------------------------------------------
+  Test Data 1   |   Test Data 1   |  Test Data 1
+  Test Data 2   |   Test Data 2   |  Test Data 2
+  Test Data 3   |   Test Data 3   |  Test Data 3
+
+
+Backward support 3 presentation type
+Forward support new presentation type - 1 component with all info

--- a/tests/_application_store_json.py
+++ b/tests/_application_store_json.py
@@ -790,9 +790,20 @@ application_store_json_template = Template(
                     "fields": [
                         {
                             "answer": [
-                                "Income Test : £2300"
+                                {
+                                "type-of-revenue-cost": "Test1",
+                                "value": 100
+                                },
+                                {
+                                "type-of-revenue-cost": "Test2",
+                                "value": 200
+                                },
+                                {
+                                "type-of-revenue-cost": "Test3",
+                                "value": 50
+                                }
                             ],
-                            "key": "MultiInputField",
+                            "key": "TzOokX",
                             "title": "Sources of income",
                             "type": "text"
                         }

--- a/tests/_application_store_json.py
+++ b/tests/_application_store_json.py
@@ -791,16 +791,19 @@ application_store_json_template = Template(
                         {
                             "answer": [
                                 {
-                                "type-of-revenue-cost": "Test1",
-                                "value": 100
+                                "Example input 1": "Test Data 1",
+                                "Example input 2": "Test Data 1",
+                                "Example input 3": "Test Data 1"
                                 },
                                 {
-                                "type-of-revenue-cost": "Test2",
-                                "value": 200
+                                "Example input 1": "Test Data 2",
+                                "Example input 2": "Test Data 2",
+                                "Example input 3": "Test Data 2"
                                 },
                                 {
-                                "type-of-revenue-cost": "Test3",
-                                "value": 50
+                                "Example input 1": "Test Data 3",
+                                "Example input 2": "Test Data 3",
+                                "Example input 3": "Test Data 3"
                                 }
                             ],
                             "key": "TzOokX",


### PR DESCRIPTION
_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
https://digital.dclg.gov.uk/jira/browse/FS-2500

Currently, the add-another component output is not consumable (going forward) by the assessment service, this is because the keys are dictated by the field name in the form builder. This form builder context is not known by assessment when extracting the information (by key) from the application payload. Instead we should use consistent keys such as "name" and "value" as below.

For now a patch has been put in place to handle the temporary "add-another" output.
