### PR TITLE
FS-2640-location-is-missing-for-some-applications

### DIFF
--- a/scripts/location_utils.py
+++ b/scripts/location_utils.py
@@ -36,6 +36,12 @@ def get_postcode_from_questions(form_questions) -> str:
                     postcode = raw_postcode.strip().replace(" ", "").upper()
                     return postcode
 
+            else:
+                print(
+                    "The key 'yEmHpp' for Project information form not found"
+                )
+                return "Not found"
+
 
 def get_all_application_ids_for_fund_round(fund_id, round_id) -> list:
     """


### PR DESCRIPTION
This PR adds a condition that will result in a "Not found" response if the Project information page for a community asset address cannot be found. This behavior will only occur in local environments since the Project information address field is required.
