### PR TITLE
FS-2683: Change query for qa complete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     rev: 3.9.2
     hooks:
     - id: flake8
+      args:
+        - --max-line-length=120
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -1,4 +1,6 @@
 """Flask Local Development Environment Configuration."""
+import logging
+
 from config.envs.default import DefaultConfig
 from fsd_utils import CommonConfig
 from fsd_utils import configclass
@@ -10,6 +12,8 @@ class DevelopmentConfig(DefaultConfig):
     SECRET_KEY = "dev"
     SESSION_COOKIE_NAME = CommonConfig.SESSION_COOKIE_NAME
     FLASK_ENV = "development"
+
+    FSD_LOG_LEVEL = logging.INFO
 
     # APIs
     APPLICATION_STORE_API_HOST = CommonConfig.TEST_APPLICATION_STORE_API_HOST

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -12,7 +12,7 @@ from db.models.assessment_record.enums import Status
 from db.models.flags import Flag
 from db.models.flags.enums import FlagType
 from db.queries.assessment_records._helpers import derive_application_values
-from db.queries.flags.queries import find_qa_complete_flag
+from db.queries.flags.queries import find_qa_complete_flags
 from db.schemas import AssessmentRecordMetadata
 from db.schemas import AssessmentSubCriteriaMetadata
 from db.schemas import AssessorTaskListMetadata
@@ -134,9 +134,18 @@ def get_metadata_for_fund_round_id(
         exclude=("jsonb_blob", "application_json_md5")
     )
 
+    application_ids = {
+        app_metadata.application_id for app_metadata in assessment_metadatas
+    }
+    application_is_qa_complete_dict = find_qa_complete_flags(application_ids)
+
     assessment_metadatas = [
         metadata_serialiser.dump(app_metadata)
-        | find_qa_complete_flag(app_metadata.application_id)
+        | {
+            "is_qa_complete": application_is_qa_complete_dict[
+                app_metadata.application_id
+            ]
+        }
         for app_metadata in assessment_metadatas
     ]
 

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -129,20 +129,18 @@ def get_metadata_for_fund_round_id(
             )
 
     assessment_metadatas = db.session.scalars(statement).all()
-
     metadata_serialiser = AssessmentRecordMetadata(
         exclude=("jsonb_blob", "application_json_md5")
     )
 
-    application_ids = {
+    app_ids = {
         app_metadata.application_id for app_metadata in assessment_metadatas
     }
-    application_is_qa_complete_dict = find_qa_complete_flags(application_ids)
-
+    app_id_is_qa_complete_dict = find_qa_complete_flags(app_ids)
     assessment_metadatas = [
         metadata_serialiser.dump(app_metadata)
         | {
-            "is_qa_complete": application_is_qa_complete_dict[
+            "is_qa_complete": app_id_is_qa_complete_dict[
                 app_metadata.application_id
             ]
         }

--- a/db/queries/flags/queries.py
+++ b/db/queries/flags/queries.py
@@ -3,6 +3,7 @@
 Joins allowed.
 """
 from typing import Dict
+from typing import Iterable
 
 from db import db
 from db.models import Flag
@@ -45,6 +46,18 @@ def retrieve_flag_for_application(application_id: str) -> dict:
     flag_metadata = metadata_serialiser.dump(flag)
 
     return flag_metadata
+
+
+def find_qa_complete_flags(application_ids: Iterable[str]) -> dict[str, bool]:
+    flags = Flag.query.filter(
+        Flag.application_id.in_(application_ids),
+        Flag.flag_type == "QA_COMPLETED",
+    ).all()
+
+    qa_completed_application_ids = {flag.application_id for flag in flags}
+    return {
+        aid: aid in qa_completed_application_ids for aid in application_ids
+    }
 
 
 def find_qa_complete_flag(application_id):

--- a/db/queries/flags/queries.py
+++ b/db/queries/flags/queries.py
@@ -56,7 +56,8 @@ def find_qa_complete_flags(application_ids: Iterable[str]) -> dict[str, bool]:
 
     qa_completed_application_ids = {flag.application_id for flag in flags}
     return {
-        aid: aid in qa_completed_application_ids for aid in application_ids
+        app_id: app_id in qa_completed_application_ids
+        for app_id in application_ids
     }
 
 

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -102,14 +102,10 @@ def seed_dev_db(c, fundround=None, appcount=None):
             while choosing:
 
                 new_line = "\n"
-                _echo_print(
-                    f"fund-rounds available to seed: {new_line} -"
-                    " {f' {new_line} - '.join(config.keys())}",
-                )
                 fund_round_input = str(
                     _echo_input(
                         "Please type the fund-round to seed:"
-                        f"fund-rounds available to seed: "
+                        f"\nfund-rounds available to seed: "
                         f"{new_line} - {f' {new_line} - '.join(config.keys())}"
                         f"{new_line} > "
                     ),
@@ -121,7 +117,7 @@ def seed_dev_db(c, fundround=None, appcount=None):
                 choosing = (
                     not _echo_input(
                         f"Would you like to insert {apps} applications"
-                        " for {fund_round_input}? y/n \n"
+                        f" for {fund_round_input}? y/n \n"
                     ).lower()
                     == "y"
                 )


### PR DESCRIPTION
### Change description

- Use a single query to get applications with a qa complete flag
- Fix f string and duplication errors in seeding script
- Set FSD log level in development configuration
- Also set line length to 120 as per the [GDS way](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#maximum-line-length-of-120-characters)

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
