### PR TITLE
BAU:  Add health-check-invocation-timeout 

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -29,3 +29,4 @@ applications:
     - assessment-store-test-db
   health-check-http-endpoint: /healthcheck
   health-check-type: http
+  health-check-invocation-timeout: 20


### PR DESCRIPTION
Change description
Adding the health checks invocation timeout to assessment store for Test env in case it may need it. 

https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#health-check-invocation-timeout
https://cli.cloudfoundry.org/en-US/v6/v3-set-health-check.html

How to test
Once this PR is merged run the e2e tests for Assessment locally and the tests should pass without any environment issues.

Screenshots of UI changes (if applicable)
N/A