### PR TITLE
bumping versions for compaitibility on M1 macs

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@ bandit
 black
 deepdiff
 invoke
-pip-tools
+pip-tools>=6.13.0
 pre-commit
 pytest
 pytest-env

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -77,13 +77,6 @@ clickclick==20.10.2
     # via
     #   -r requirements.txt
     #   connexion
-colorama==0.4.6
-    # via
-    #   -r requirements.txt
-    #   bandit
-    #   build
-    #   click
-    #   pytest
 colored==1.4.4
     # via -r requirements-dev.in
 commonmark==0.9.1
@@ -154,10 +147,6 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.29
     # via bandit
-greenlet==2.0.2
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.txt
@@ -280,7 +269,7 @@ pbr==5.11.0
     #   stevedore
 pep517==0.13.0
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements-dev.in
 platformdirs==2.5.4
     # via
@@ -296,7 +285,7 @@ prance==0.22.11.4.0
     # via -r requirements.txt
 pre-commit==3.1.0
     # via -r requirements-dev.in
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements.txt
 pycparser==2.21
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -14,10 +14,9 @@ Flask
 #   Database
 #-----------------------------------
 SQLAlchemy[mypy]
-# 3 has came out but our testing framework isn't updated to use it yet.
 Flask-SQLAlchemy>=3.0.3
 Flask-Migrate
-psycopg2-binary
+psycopg2-binary==2.9.6
 alembic-utils
 marshmallow-sqlalchemy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,6 @@ click==8.1.3
     #   flask
 clickclick==20.10.2
     # via connexion
-colorama==0.4.6
-    # via click
 commonmark==0.9.1
     # via rich
 connexion==2.14.2
@@ -83,8 +81,6 @@ flupy==1.2.0
     # via alembic-utils
 funding-service-design-utils==2.0.1
     # via -r requirements.in
-greenlet==2.0.2
-    # via sqlalchemy
 gunicorn==20.1.0
     # via funding-service-design-utils
 idna==3.4
@@ -153,7 +149,7 @@ ply==3.11
     # via jsonpath-rw
 prance==0.22.11.4.0
     # via -r requirements.in
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements.in
 pycparser==2.21
     # via cffi


### PR DESCRIPTION
### Change description
Upping the psycopg2-binary to 2.9.6 and upgrading pip-tools so it works locally

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Clone code to a mac, create a venv, install requirements and run


### Screenshots of UI changes (if applicable)
n/a