### PR TITLE
FS-3045 Adding fix for formatting month year in add another

### DIFF
--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -192,7 +192,7 @@ def format_add_another_component_contents(
             frontend_format = _MULTI_INPUT_FORMAT_FRONTEND.get(
                 column_config["type"], "text"
             )
-            
+
             pre_frontend_formatter = _MULTI_INPUT_FRE_FRONTEND_FORMATTERS.get(
                 column_config["type"], lambda x: x
             )
@@ -202,13 +202,17 @@ def format_add_another_component_contents(
                 if answers
                 else None
             )
-          
+
             if frontend_format == "monthYearField":
-                formatted_answers = [
-                    f"{answer[component_id + '__month']}/"
-                    f"{answer[component_id + '__year']}"
-                    for answer in answers                    
-                ] if answers else None
+                formatted_answers = (
+                    [
+                        f"{answer[component_id + '__month']}/"
+                        f"{answer[component_id + '__year']}"
+                        for answer in answers
+                    ]
+                    if answers
+                    else None
+                )
 
             if formatted_answers:
                 table.append([title, formatted_answers, frontend_format])

--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -155,7 +155,7 @@ _MULTI_INPUT_FORMAT_FRONTEND = defaultdict(
         # the default should handle these, but let's be explicit
         "RadioField": "text",
         "textField": "text",
-        "MonthYearField": "text",
+        "MonthYearField": "monthYearField",
         "yesNoField": "text",
     },
 )
@@ -192,6 +192,7 @@ def format_add_another_component_contents(
             frontend_format = _MULTI_INPUT_FORMAT_FRONTEND.get(
                 column_config["type"], "text"
             )
+            
             pre_frontend_formatter = _MULTI_INPUT_FRE_FRONTEND_FORMATTERS.get(
                 column_config["type"], lambda x: x
             )
@@ -201,6 +202,13 @@ def format_add_another_component_contents(
                 if answers
                 else None
             )
+          
+            if frontend_format == "monthYearField":
+                formatted_answers = [
+                    f"{answer[component_id + '__month']}/"
+                    f"{answer[component_id + '__year']}"
+                    for answer in answers                    
+                ] if answers else None
 
             if formatted_answers:
                 table.append([title, formatted_answers, frontend_format])

--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -206,7 +206,7 @@ def format_add_another_component_contents(
             if frontend_format == "monthYearField":
                 formatted_answers = (
                     [
-                        f"{answer[component_id + '__month']}/"
+                        f"{answer[component_id + '__month']}-"
                         f"{answer[component_id + '__year']}"
                         for answer in answers
                     ]

--- a/tests/test_get_sub_criteria.py
+++ b/tests/test_get_sub_criteria.py
@@ -120,7 +120,11 @@ def test_deprecated_sort_add_another_component_contents(
             [  # expected_nested_table_tuple
                 ["Example text child", ["test1", "test2"], "text"],
                 ["Example currency child", [1, 2], "currency"],
-                ["Example month year child", ["01-2020", "02-2020"], "monthYearField"],
+                [
+                    "Example month year child",
+                    ["01-2020", "02-2020"],
+                    "monthYearField",
+                ],
                 ["Example yes no child", ["Yes", "No"], "text"],
                 ["Example radio child", ["Low", "High"], "text"],
                 [

--- a/tests/test_get_sub_criteria.py
+++ b/tests/test_get_sub_criteria.py
@@ -103,7 +103,7 @@ def test_deprecated_sort_add_another_component_contents(
                 {
                     "aaaaaa": "test1",
                     "bbbbbb": 1,
-                    "cccccc": "2020-01",
+                    "cccccc": {"cccccc__month": "01", "cccccc__year": "2020"},
                     "dddddd": True,
                     "eeeeee": "low",
                     "ffffff": "test\r\n1",
@@ -111,7 +111,7 @@ def test_deprecated_sort_add_another_component_contents(
                 {
                     "aaaaaa": "test2",
                     "bbbbbb": 2,
-                    "cccccc": "2020-02",
+                    "cccccc": {"cccccc__month": "02", "cccccc__year": "2020"},
                     "dddddd": False,
                     "eeeeee": "high",
                     "ffffff": "test\r\n2",
@@ -120,7 +120,7 @@ def test_deprecated_sort_add_another_component_contents(
             [  # expected_nested_table_tuple
                 ["Example text child", ["test1", "test2"], "text"],
                 ["Example currency child", [1, 2], "currency"],
-                ["Example month year child", ["2020-01", "2020-02"], "text"],
+                ["Example month year child", ["01-2020", "02-2020"], "monthYearField"],
                 ["Example yes no child", ["Yes", "No"], "text"],
                 ["Example radio child", ["Low", "High"], "text"],
                 [


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-3045


### Change description
Adding formatting for the month year fields so they not longer display as a object with key value pair when viewing themes with a add another section

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
If you navigate to the Proposal summary and milestones sub criteria and select the Milestones theme, you will see the the month year field now longer displays and a object with key value pairs


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/97108643/0896ef97-55be-4057-94f3-e21a958c73b3)
