### PR TITLE
bau-add-optional-text-to-cofr3-config

### DIFF
--- a/config/mappings/cof_mapping_parts/cof_r3_scored_criteria.py
+++ b/config/mappings/cof_mapping_parts/cof_r3_scored_criteria.py
@@ -114,7 +114,7 @@ scored_criteria = [
                                 "form_name": "local-support-cof-r3-w1",
                                 "field_type": "clientSideFileUploadField",
                                 "presentation_type": "s3bucketPath",
-                                "question": "Upload supporting evidence",
+                                "question": "Upload supporting evidence (optional)",
                                 "path": "your-support-for-the-project",
                             },
                         ],


### PR DESCRIPTION
adding '(optional)' text to engangement -> local support -> upload evidence 