### PR TITLE
FS-3098: Add missing field from NSTF config

### DIFF
--- a/config/mappings/nstf_mapping_parts/nstf_r2_unscored_sections.py
+++ b/config/mappings/nstf_mapping_parts/nstf_r2_unscored_sections.py
@@ -54,7 +54,16 @@ unscored_sections = [
                                 "form_name": "organisation-information-ns",
                                 "field_type": "numberField",
                                 "presentation_type": "text",
-                                "question": "What is your organisation's annual turnover?",
+                                "question": "What is your organisation's annual turnover? "
+                                "(1 April 2022 to 31 March 2023)",
+                            },
+                            {
+                                "field_id": "zuCRBk",
+                                "form_name": "organisation-information-ns",
+                                "field_type": "numberField",
+                                "presentation_type": "text",
+                                "question": "What is your organisation's annual turnover? "
+                                "(1 April 2021 to 31 March 2022)",
                             },
                             {
                                 "field_id": "NENGMj",


### PR DESCRIPTION
### Change description

- Add missing `zuCRBk` from NSTF config
- Will now show in the answers
- Also add dates so we can differentiate between values

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines


### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/117724519/4b4cd741-ffd4-4a82-a37c-3515a386c532)

