### PR TITLE
FS-3180 - Moving the other names questions to correct position

### DIFF
--- a/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
@@ -97,7 +97,7 @@ unscored_sections = [
                                 "field_type": "textField",
                                 "presentation_type": "text",
                                 "question": "Company registration number",
-                            },                            
+                            },
                             {
                                 "field_id": "aHIGbK",
                                 "form_name": "organisation-information-cof-r3-w1",

--- a/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
@@ -29,6 +29,13 @@ unscored_sections = [
                                 "question": "Organisation name",
                             },
                             {
+                                "field_id": "iBCGxY",
+                                "form_name": "organisation-information-cof-r3-w1",
+                                "field_type": "yesNoField",
+                                "presentation_type": "text",
+                                "question": "Does your organisation use any other names?",
+                            },
+                            {
                                 "field_id": "PHFkCs",
                                 "form_name": "organisation-information-cof-r3-w1",
                                 "field_type": "textField",
@@ -90,14 +97,7 @@ unscored_sections = [
                                 "field_type": "textField",
                                 "presentation_type": "text",
                                 "question": "Company registration number",
-                            },
-                            {
-                                "field_id": "iBCGxY",
-                                "form_name": "organisation-information-cof-r3-w1",
-                                "field_type": "yesNoField",
-                                "presentation_type": "text",
-                                "question": "Does your organisation use any other names?",
-                            },
+                            },                            
                             {
                                 "field_id": "aHIGbK",
                                 "form_name": "organisation-information-cof-r3-w1",


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3180

### Change description
"Does your organisation use any other names?" is now in the correct position. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Check the organisation information page

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/97108643/58f483af-ee6b-41e7-986c-c7a59423bed3)
