### PR TITLE
BAU: Bump Assessment Store Memory on Test env to 512M

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,7 +16,7 @@ applications:
   services:
     - assessment-store-dev-db
 - name: funding-service-design-assessment-store-test
-  memory: 128M
+  memory: 512M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: scripts/run_migrations_paas.py && gunicorn wsgi:app -c run/gunicorn/devtest.py


### PR DESCRIPTION
### Change description

Bump assessment store memory to reduce performance degradation on Test Env and allow e2e tests for Assessment to run smoothly on Test env.



### How to test
N/A


### Screenshots of UI changes (if applicable)
N/A

