### PR TITLE
BAU: Fix wrong identifier

### DIFF
--- a/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/cof_r3_unscored_sections.py
@@ -489,7 +489,7 @@ unscored_sections = [
                                 "question": "Asset type",
                             },
                             {
-                                "field_id": "VxBLMN",
+                                "field_id": "aJGyCR",
                                 "form_name": "asset-information-cof-r3-w1",
                                 "field_type": "radiosField",
                                 "presentation_type": "text",


### PR DESCRIPTION
- Noticed this when working on support with Pete/Kavya
- Change identifier so the "Other" answer shows on assessment

![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/117724519/fcbcaf62-0b03-47ef-8ef5-03f104137533)
