### PR TITLE
adding method to count tag usage

### DIFF
--- a/.github/workflows/copilot.yml
+++ b/.github/workflows/copilot.yml
@@ -1,0 +1,59 @@
+name: Copilot Workflows
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+        environment:
+          description:  Which AWS Account to use
+          type: choice
+          required: true
+          options:
+          - test
+        # Shared workflow consideration
+        # application:
+        #   description:  Application Name
+        #   type: string/choice
+        # - notification
+        #   required: true
+        init:
+          description: Initialise the application?
+          type: boolean
+          default: false
+        service:
+          description: Service Name
+          type: string
+          required: true
+          default: 'funding-service-design-assessment-store'
+        port:
+          description: Access port
+          type: string
+          default: '80'
+        type:
+          description: Type of service to deploy
+          type: choice
+          options:
+          - 'Backend Service'
+          - 'Load Balanced Web Service'
+          - 'Request-Driven Web Service'
+          - 'Scheduled Job'
+          - 'Worker Service'
+          default: 'Backend Service'
+
+
+jobs:
+  deployment:
+    concurrency: deploy-${{ inputs.environment || 'test' }} # Forces only one workflow at a time can run on the environment
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'test' }}
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v3
+
+      - name: Get current date
+        id: currentdatetime
+        run: echo "::set-output name=datetime::$(date +'%Y%m%d%H%M%S')"

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -6,6 +6,7 @@ from .assessment_routes import assessment_stats_for_fund_round_id
 from .assessment_routes import create_flag_v2_for_application
 from .assessment_routes import get_all_flags_v2_for_application
 from .assessment_routes import get_all_uploaded_document_theme_answers
+from .assessment_routes import get_application_data_for_export
 from .assessment_routes import get_application_json
 from .assessment_routes import get_assessor_task_list_state
 from .assessment_routes import get_banner_state
@@ -65,4 +66,5 @@ __all__ = [
     "get_tag",
     "post_qa_complete_for_application",
     "qa_complete_record_for_application",
+    "get_application_data_for_export",
 ]

--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -25,6 +25,7 @@ from db.queries.assessment_records.queries import get_application_jsonb_blob
 from db.queries.assessment_records.queries import (
     get_assessment_sub_critera_state,
 )
+from db.queries.assessment_records.queries import get_export_application_data
 from db.queries.assessment_records.queries import get_metadata_for_application
 from db.queries.assessment_records.queries import (
     select_tags_associated_with_assessment,
@@ -518,3 +519,9 @@ def get_flag_v2(flag_id: str):
     flags = get_flag_by_id(flag_id)
     flag_schema = AssessmentFlagSchema()
     return flag_schema.dump(flags, many=True)[0]
+
+
+def get_application_data_for_export(fund_id: str, round_id: str) -> List[Dict]:
+    app_list = get_export_application_data(fund_id=fund_id, round_id=round_id)
+
+    return app_list

--- a/api/routes/tag_routes.py
+++ b/api/routes/tag_routes.py
@@ -7,6 +7,7 @@ from db.schemas.schemas import JoinedTagSchema
 from db.schemas.schemas import TagSchema
 from db.schemas.schemas import TagTypeSchema
 from flask import abort
+from flask import current_app
 from flask import request
 
 
@@ -14,12 +15,13 @@ def get_tags_for_fund_round(fund_id, round_id):
 
     tags = select_tags_for_fund_round(fund_id, round_id)
 
-    if tags:
-        serialiser = JoinedTagSchema()
-        serialised_tags = [serialiser.dump(r) for r in tags]
-        return serialised_tags
-
-    abort(404, f"No tags found for fund__round: {fund_id}__{round_id}.")
+    if not tags:
+        current_app.logger.warning(
+            f"No tags found for fund__round: {fund_id}__{round_id}."
+        )
+    serialiser = JoinedTagSchema()
+    serialised_tags = [serialiser.dump(r) for r in tags]
+    return serialised_tags
 
 
 def seed_and_get_tag_types():

--- a/api/routes/tag_routes.py
+++ b/api/routes/tag_routes.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from db.queries.tags.queries import count_tag_usage
 from db.queries.tags.queries import get_tag_by_id
 from db.queries.tags.queries import insert_tags
 from db.queries.tags.queries import select_tags_for_fund_round
@@ -65,3 +66,8 @@ def get_tag(fund_id, round_id, tag_id):
     if not tag:
         return abort(404)
     return JoinedTagSchema().dump(tag)
+
+
+def get_count_of_tag_usage(fund_id, round_id, tag_id):
+    result = count_tag_usage(fund_id, round_id, tag_id)
+    return {"count": result}

--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -126,6 +126,7 @@ applicant_info_mapping = {
         "SnLGJE",
         "NlHSBg",
         "FhBkJQ",
+        "ZQolYb",
         "VhkCbM",
     },
 }

--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -114,3 +114,18 @@ fund_round_data_key_mappings = {
         "funding_two": ["XsAoTv", "JtBjFp"],
     },
 }
+
+applicant_info_mapping = {
+    "13b95669-ed98-4840-8652-d6b7a19964db": {
+        "SnLGJE",
+        "CDEwxp",
+        "DvBqCJ",
+        "mhYQzL",
+    },
+    "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4": {
+        "SnLGJE",
+        "NlHSBg",
+        "FhBkJQ",
+        "VhkCbM",
+    },
+}

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -3,6 +3,7 @@
 Joins allowed.
 """
 import json
+from collections import OrderedDict
 from typing import Dict
 from typing import List
 
@@ -791,4 +792,17 @@ def get_export_application_data(fund_id: str, round_id: str) -> List[Dict]:
                         applicant_info[field["title"]] = field["answer"]
         finalList.append(applicant_info)
 
+    add_missing_elements_with_empty_values(finalList)
     return finalList
+
+
+# adds miissing elements for use in the csv
+def add_missing_elements_with_empty_values(finalList):
+    missing_keys_order = list(finalList[0].keys())
+
+    for field in finalList:
+        ordered_dict = OrderedDict()
+        for key in missing_keys_order:
+            ordered_dict[key] = field.get(key, "")
+        field.clear()
+        field.update(ordered_dict)

--- a/db/queries/tags/queries.py
+++ b/db/queries/tags/queries.py
@@ -1,9 +1,12 @@
 from typing import List
 
 from db import db
+from db.models.assessment_record.tag_association import TagAssociation
 from db.models.tag.tag_types import TagType
 from db.models.tag.tags import Tag
 from flask import current_app
+from sqlalchemy import func
+from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
 
@@ -107,3 +110,14 @@ def get_tag_by_id(fund_id: str, round_id: str, tag_id: str) -> Tag:
 
 def select_tags_types() -> List[TagType]:
     return db.session.query(TagType).all()
+
+
+def count_tag_usage(fund_id, round_id, tag_id) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(TagAssociation)
+        .where(TagAssociation.tag_id == tag_id)
+        .where(TagAssociation.associated == True)  # noqa:E712
+    )
+    result = db.session.execute(stmt).one()
+    return result[0]

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -1248,6 +1248,38 @@ paths:
             application/json:
               schema:
                 $ref: "components.yml#/components/schemas/Error"
+  '/funds/{fund_id}/rounds/{round_id}/tags/{tag_id}/count':
+    get:
+      tags:
+        - tag management
+      summary: Get the number of active associations for this tag
+      description: Returns the number of assessments that currently have this tag.
+      operationId: api.routes.tag_routes.get_count_of_tag_usage
+      parameters:
+        - in: path
+          name: fund_id
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: round_id
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: tag_id
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          description: Count of assessments using this tag
+          content:
+            application/json:
+              schema:
+                  properties:
+                    count:
+                      type: integer
   '/funds/{fund_id}/rounds/{round_id}/tags':
     get:
       tags:

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -1330,3 +1330,32 @@ paths:
                 type: array
                 items:
                   $ref: 'components.yml#/components/schemas/TagType'
+  '/application_fields_export/{fund_id}/{round_id}':
+      parameters:
+      - name: fund_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: path
+      - name: round_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: path
+      get:
+        tags:
+          - assessments
+        summary: Search assessments for export by fields
+        description: List all assessments for export
+        operationId: api.routes.get_application_data_for_export
+        responses:
+          200:
+            description: SUCCESS - A list of assessments information for export
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: 'components.yml#/components/schemas/Assessment'


### PR DESCRIPTION
### Change description
As per the prototype we need to display how many assessments are affected by a tag when editing, this PR adds that method to the assessment store
https://fsd-pre-award.herokuapp.com/s42-tags/application/tags/edit?id=5&fundID=cof

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

