### PR TITLE
Fs 3273 output tracker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -164,7 +164,7 @@
           "-c",
           "pytest.ini",
           "-k",
-          "test_route_fund_dashboard_shows_flagged" // modify this accordingly
+          "test_get_application_fields_export" // modify this accordingly
       ],
       "justMyCode": false
   },

--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -25,7 +25,7 @@ from db.queries.assessment_records.queries import get_application_jsonb_blob
 from db.queries.assessment_records.queries import (
     get_assessment_sub_critera_state,
 )
-from db.queries.assessment_records.queries import get_export_application_data
+from db.queries.assessment_records.queries import get_export_data
 from db.queries.assessment_records.queries import get_metadata_for_application
 from db.queries.assessment_records.queries import (
     select_tags_associated_with_assessment,
@@ -47,6 +47,9 @@ from db.schemas.schemas import JoinedTagAssociationSchema
 from db.schemas.schemas import TagAssociationSchema
 from flask import current_app
 from flask import request
+from config.mappings.assessment_mapping_fund_round import (
+    applicant_info_mapping,
+)
 
 
 def assessment_metadata_for_application_id(application_id: str) -> Dict:
@@ -521,7 +524,7 @@ def get_flag_v2(flag_id: str):
     return flag_schema.dump(flags, many=True)[0]
 
 
-def get_application_data_for_export(fund_id: str, round_id: str) -> List[Dict]:
-    app_list = get_export_application_data(fund_id=fund_id, round_id=round_id)
+def get_application_data_for_export(fund_id: str, round_id: str, report_type: str) -> List[Dict]:
+    app_list = get_export_data(fund_id=fund_id, round_id=round_id, report_type=report_type, list_of_fields=applicant_info_mapping[fund_id])
 
     return app_list

--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -117,16 +117,33 @@ fund_round_data_key_mappings = {
 
 applicant_info_mapping = {
     "13b95669-ed98-4840-8652-d6b7a19964db": {
-        "SnLGJE",
-        "CDEwxp",
-        "DvBqCJ",
-        "mhYQzL",
+        "OUTPUT_TRACKER": {
+            "form_fields": {
+                "SnLGJE",
+                "CDEwxp",
+                "DvBqCJ",
+                "mhYQzL",
+            },
+            "score_fields": {
+                "Application ID",
+                "Score Subcriteria",
+                "Score",            
+                "Score Date Created"
+            }
+        }
     },
     "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4": {
-        "SnLGJE",
-        "NlHSBg",
-        "FhBkJQ",
-        "ZQolYb",
-        "VhkCbM",
+        "ASSESSOR_EXPORT": {
+            "form_fields": {
+                "SnLGJE",
+                "NlHSBg",
+                "FhBkJQ",
+                "ZQolYb",
+                "VhkCbM",
+            }
+        },
+        "OUTPUT_TRACKER": {
+
+        }
     },
 }

--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -119,10 +119,18 @@ applicant_info_mapping = {
     "13b95669-ed98-4840-8652-d6b7a19964db": {
         "OUTPUT_TRACKER": {
             "form_fields": {
-                "SnLGJE",
+                "opFJRm",
+                "fUMWcd",
                 "CDEwxp",
-                "DvBqCJ",
-                "mhYQzL",
+                "nURkuc",
+                "pVBwci",
+                "WDouQc",
+                "SGjmSM",
+                "wTdyhk",
+                "GRWtfV",
+                "zvPzXN",
+                "QUCvFy",
+                "pppiYl"
             },
             "score_fields": {
                 "Application ID",

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -852,7 +852,7 @@ def combine_dicts(applications_list, scores_list):
     combined_list = []
 
     if len(applications_list) == 0 and len(scores_list) == 0:
-        return combine_dicts
+        return combined_list
     if len(applications_list) == 0:
         return scores_list
     if len(scores_list) == 0:

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -3,6 +3,7 @@
 Joins allowed.
 """
 import json
+from collections import OrderedDict
 from typing import Dict
 from typing import List
 
@@ -791,4 +792,17 @@ def get_export_application_data(fund_id: str, round_id: str) -> List[Dict]:
                         applicant_info[field["title"]] = field["answer"]
         finalList.append(applicant_info)
 
+    add_missing_elements_with_empty_values(finalList)
     return finalList
+
+
+# adds miissing elements for use in the csv
+def add_missing_elements_with_empty_values(finalList):
+    missing_keys_order = list(finalList[0].keys())
+
+    for field in finalList:
+        ordered_dict = OrderedDict()
+        for key in missing_keys_order:
+            ordered_dict[key] = field.get(key, "")
+        field.clear()
+        field.update(ordered_dict)

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -7,9 +7,6 @@ from collections import OrderedDict
 from typing import Dict
 from typing import List
 
-from config.mappings.assessment_mapping_fund_round import (
-    applicant_info_mapping,
-)
 from db import db
 from db.models.assessment_record import AssessmentRecord
 from db.models.assessment_record import TagAssociation

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -649,12 +649,11 @@ def get_assessment_records_by_round_id(round_id, selected_fields=None):
         information for each subcriteria of the AssessmentRecords that match the given round_id.
     """
     default_fields = [
-        "Short id",
+        "Application ID",
         "Score Subcriteria",
         "Score",
         "Score Justification",
         "Score Date Created",
-        "Application ID",
     ]
 
     # If selected_fields is not provided, use the default_fields.
@@ -696,10 +695,9 @@ def get_assessment_records_by_round_id(round_id, selected_fields=None):
     for score in latest_scores:
 
         score_data = {
-            "Short id": AssessmentRecord.query.get(
+            "Application ID": AssessmentRecord.query.get(
                 score.application_id
             ).short_id,
-            "Application ID": score.application_id,
             "Score Subcriteria": score.sub_criteria_id,
             "Score": score.score,
             "Score Justification": score.justification,
@@ -802,7 +800,7 @@ def get_export_data(
 
     if len(form_fields) != 0:
         for assessment in assessment_metadatas:
-            applicant_info = {"Application ID": assessment.application_id}
+            applicant_info = {"Application ID": assessment.short_id}
             forms = assessment.jsonb_blob["forms"]
             for form in forms:
                 questions = form["questions"]

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -1330,7 +1330,7 @@ paths:
                 type: array
                 items:
                   $ref: 'components.yml#/components/schemas/TagType'
-  '/application_fields_export/{fund_id}/{round_id}':
+  '/application_fields_export/{fund_id}/{round_id}/{report_type}':
       parameters:
       - name: fund_id
         in: path
@@ -1339,6 +1339,12 @@ paths:
           type: string
           format: path
       - name: round_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: path
+      - name: report_type
         in: path
         required: true
         schema:

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -284,7 +284,7 @@ def test_bulk_update_location_json_blob(
 
 @pytest.mark.apps_to_insert([test_input_data[0]])
 def test_get_data(seed_application_records):
-    #TODO expand this test with more scenarios
+    # TODO expand this test with more scenarios
     picked_row = get_assessment_record(
         seed_application_records[0]["application_id"]
     )
@@ -300,19 +300,20 @@ def test_get_data(seed_application_records):
     }
     create_score_for_app_sub_crit(**assessment_payload)
 
-    data = get_export_data(picked_row.fund_id, picked_row.round_id, "OUTPUT_TRACKER",  {
+    data = get_export_data(
+        picked_row.fund_id,
+        picked_row.round_id,
+        "OUTPUT_TRACKER",
+        {
             "OUTPUT_TRACKER": {
                 "form_fields": {"aHIGbK", "aAeszH", "ozgwXq", "KAgrBz"}
             }
-        })
+        },
+    )
 
     assert data[0]["Charity number "] == "Test"
-    assert (
-        data[0]["Do you need to do any further feasibility work?"] is False
-    )
+    assert data[0]["Do you need to do any further feasibility work?"] is False
     assert data[0]["Project name"] == "Save the humble pub in Bangor"
-    assert (
-        data[0]["Risks to your project (document upload)"] == "sample1.doc"
-    )
-    assert (data[0]["Score"] == 5)
-    assert (data[0]["Score Justification"] == "great")
+    assert data[0]["Risks to your project (document upload)"] == "sample1.doc"
+    assert data[0]["Score"] == 5
+    assert data[0]["Score Justification"] == "great"

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -12,8 +12,10 @@ from db.queries.assessment_records.queries import (
     bulk_update_location_jsonb_blob,
 )
 from db.queries.assessment_records.queries import find_assessor_task_list_state
+from db.queries.assessment_records.queries import get_export_data
 from db.queries.comments.queries import create_comment_for_application_sub_crit
 from db.queries.comments.queries import get_comments_for_application_sub_crit
+from db.queries.scores.queries import create_score_for_app_sub_crit
 from tests._expected_responses import BULK_UPDATE_LOCATION_JSONB_BLOB
 from tests._helpers import get_assessment_record
 from tests.conftest import test_input_data
@@ -278,3 +280,39 @@ def test_bulk_update_location_json_blob(
         .first()
     )
     assert assessment_record.location_json_blob == expected_data
+
+
+@pytest.mark.apps_to_insert([test_input_data[0]])
+def test_get_data(seed_application_records):
+    #TODO expand this test with more scenarios
+    picked_row = get_assessment_record(
+        seed_application_records[0]["application_id"]
+    )
+    application_id = picked_row.application_id
+    sub_criteria_id = "app-info"
+
+    assessment_payload = {
+        "application_id": application_id,
+        "sub_criteria_id": sub_criteria_id,
+        "score": 5,
+        "justification": "great",
+        "user_id": "test",
+    }
+    create_score_for_app_sub_crit(**assessment_payload)
+
+    data = get_export_data(picked_row.fund_id, picked_row.round_id, "OUTPUT_TRACKER",  {
+            "OUTPUT_TRACKER": {
+                "form_fields": {"aHIGbK", "aAeszH", "ozgwXq", "KAgrBz"}
+            }
+        })
+
+    assert data[0]["Charity number "] == "Test"
+    assert (
+        data[0]["Do you need to do any further feasibility work?"] is False
+    )
+    assert data[0]["Project name"] == "Save the humble pub in Bangor"
+    assert (
+        data[0]["Risks to your project (document upload)"] == "sample1.doc"
+    )
+    assert (data[0]["Score"] == 5)
+    assert (data[0]["Score Justification"] == "great")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -528,7 +528,7 @@ def test_get_application_fields_export(
     )
 
     result = client.get(
-        f"/application_fields_export/{fund_id}/{round_id}"
+        f"/application_fields_export/{fund_id}/{round_id}/OUTPUT_TRACKER"
     ).json  # noqa
 
     assert len(result) == 4

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -524,11 +524,11 @@ def test_get_application_fields_export(
     monkeypatch.setitem(
         applicant_info_mapping,
         f"{fund_id}",
-        {"aHIGbK", "aAeszH", "ozgwXq", "KAgrBz"},
+        {"ASSESSOR_EXPORT": {"form_fields": {"aHIGbK", "aAeszH", "ozgwXq", "KAgrBz"}}},
     )
 
     result = client.get(
-        f"/application_fields_export/{fund_id}/{round_id}/OUTPUT_TRACKER"
+        f"/application_fields_export/{fund_id}/{round_id}/ASSESSOR_EXPORT"
     ).json  # noqa
 
     assert len(result) == 4


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3273

### Change description
Added a output tracker so user can run the report themselves. 

Iv tried to make this partially dynamic so eventually we could potentially pass in the field we want from a UI and run a report that way

to be used with https://github.com/communitiesuk/funding-service-design-assessment/pull/369

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Click the new Assessment tracker export link on the landing page as highlighted from the picture


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/97108643/9e1216c8-3e85-40c8-b8df-a790608b7660)
