### PR TITLE
add fund and round to get progress stats

### DIFF
--- a/api/routes/progress_routes.py
+++ b/api/routes/progress_routes.py
@@ -28,5 +28,5 @@ def get_progress_for_applications(
         app["progress"] = int(
             100 * app["scored_sub_criterias"] / len(scored_sub_crit_list)
         )
-    # test commit
+
     return app_prog_list

--- a/api/routes/progress_routes.py
+++ b/api/routes/progress_routes.py
@@ -25,5 +25,5 @@ def get_progress_for_applications(application_ids: List[str]) -> List[dict]:
         app["progress"] = int(
             100 * app["scored_sub_criterias"] / len(scored_sub_crit_list)
         )
-
+    # test commit
     return app_prog_list

--- a/api/routes/progress_routes.py
+++ b/api/routes/progress_routes.py
@@ -1,19 +1,22 @@
+import copy
 from typing import List
 
-from config.mappings.cof_mapping_parts.cof_r2_scored_criteria import (
-    scored_criteria,
-)
+from config import Config
 from db.queries.progress.queries import get_progress_for_app
 from flask import request
 
 
-def post_progress_for_applications() -> List[dict]:
+def post_progress_for_applications(fund_id, round_id) -> List[dict]:
     application_ids = request.get_json()["application_ids"]
-    return get_progress_for_applications(application_ids)
+    return get_progress_for_applications(application_ids, fund_id, round_id)
 
 
-def get_progress_for_applications(application_ids: List[str]) -> List[dict]:
-
+def get_progress_for_applications(
+    application_ids: List[str], fund_id, round_id
+) -> List[dict]:
+    scored_criteria = copy.deepcopy(
+        Config.ASSESSMENT_MAPPING_CONFIG[f"{fund_id}:{round_id}"]
+    )["scored_criteria"]
     scored_sub_crit_list = [
         subcrit["id"]
         for crit in scored_criteria

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -931,7 +931,20 @@ paths:
                 type: object
                 items:
                   $ref: 'components.yml#/components/schemas/Comment'
-  '/progress':
+  '/progress/{fund_id}/{round_id}':
+    parameters:
+    - name: fund_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: path
+    - name: round_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: path
     post:
       tags:
         - progress

--- a/tests/test_db_scores.py
+++ b/tests/test_db_scores.py
@@ -123,6 +123,8 @@ def test_get_progress_for_applications(seed_application_records):
 
     application_id_1 = seed_application_records[0]["application_id"]
     application_id_2 = seed_application_records[1]["application_id"]
+    fund_id = seed_application_records[0]["fund_id"]
+    round_id = seed_application_records[0]["round_id"]
     sub_criteria_ids = ["benefits", "engagement"]
 
     score_payload_1 = {
@@ -160,7 +162,7 @@ def test_get_progress_for_applications(seed_application_records):
         ]
     }
     application_progress_list = get_progress_for_applications(
-        [application_id_1, application_id_2]
+        [application_id_1, application_id_2], fund_id, round_id
     )
 
     assert len(application_progress_list) == 2


### PR DESCRIPTION
Bug fix: Team dashboard - Progress counter is displaying based on the amount of scored sub criteria for a round.
https://dluhcdigital.atlassian.net/browse/FS-3291
**BEFORE**
<img width="1345" alt="Screenshot 2023-08-04 at 15 21 44" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/95699325/9e43e919-fd44-44cb-934a-3d903d6938cc">

**AFTER**
<img width="1345" alt="Screenshot 2023-08-04 at 15 22 41" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/95699325/255cd34c-af81-4499-8acc-6b371503ff18">

