### PR TITLE
FS-3440 log location extraction errors to sentry

### DIFF
--- a/db/queries/assessment_records/_helpers.py
+++ b/db/queries/assessment_records/_helpers.py
@@ -155,6 +155,10 @@ def derive_application_values(application_json):
         address = get_answer_value(application_json, address_key)
         raw_postcode = address.split(",")[-1].strip().replace(" ", "").upper()
         location_data = get_location_json_from_postcode(raw_postcode)
+        if not location_data:
+            print(
+                f"Invalid postcode '{raw_postcode}' provided for the application: {application_id}."
+            )
     except Exception:
         print(
             "Could not extract address from application: "

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -251,6 +251,12 @@ def bulk_insert_application_record(
 
         derived_values = derive_application_values(single_application_json)
 
+        if derived_values["location_json_blob"]["error"]:
+            current_app.logger.error(
+                "Location key not found or invalid postcode provided for the "
+                f"application: {derived_values['application_id']}."
+            )
+
         row = {
             **derived_values,
             "jsonb_blob": single_application_json,


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3440

### Description
Currently location extraction errors are not logged in sentry during application import
- Log sentry error when location keys are not valid or invalid postcode provided


### How to test
- Submit an application with invalid postcode in the projection information section
- Wait for the automatic import to trigger (send & receive message (~ 60sec))
- Observe that import should be successful & location errors are logged to sentry (or in assessment container logs if testing locally)

### Screenshots of UI changes (if applicable)
