### PR TITLE
FS-3441 added yelp hook for secrets

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,8 @@ FLASK_APP=app.py
 FLASK_ENV=development
 FLASK_RUN_PORT=5000
 FLASK_RUN_HOST=localhost
+
+# Below credentials belongs to local development server. Do not commit any external services credentials
 DATABASE_URL=postgresql://postgres:password@localhost:5432/assessment_store
 APPLICATION_STORE_API_HOST=http://localhost:3002
 AWS_ACCESS_KEY_ID=FSDIOSFODNN7EXAMPLE

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -48,10 +48,10 @@
         perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
         perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
         perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
-        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
-        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
-        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
-        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
+        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev  # pragma: allowlist secret
         run_performance_tests: true
         run_e2e_tests: false
       secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
   hooks:
     - id: docformatter
       args: [--exclude=**/__init__.py --check]
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  -   id: detect-secrets
+      args: ['--disable-plugin', 'HexHighEntropyString']
+      exclude: .env.development

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Built with Flask.
 ## Quickstart / TL;DR
 If on windows: use `python` instead of `python3`, `set` instead of `export`, and `.venv\Scripts\activate` instead of `.venv/bin/activate`.
 
-```
+```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements-dev.txt
 docker container run -e POSTGRES_PASSWORD=postgres -p 5432:5432 --name=assess_store_postgres -e POSTGRES_DB=assess_store_dev postgres
+# pragma: allowlist nextline secret
 export DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/assess_store_dev'
 flask run
 ```
@@ -91,6 +92,7 @@ Enter the virtual environment and install dependencies as described above, then:
 ### Create and seed local DB
 - Make sure your local `DATABASE_URL` env var is set to your local postgres db (this doesn't need to actually exist yet), eg:
 
+        # pragma: allowlist nextline secret
         DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_assess_store
 
 - Use `tasks\db_tasks.py` to create and seed this DB (follow command prompts for what data to create):

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -6,7 +6,7 @@ from fsd_utils import configclass
 @configclass
 class DevConfig(DefaultConfig):
 
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -9,7 +9,7 @@ from fsd_utils import configclass
 @configclass
 class DevelopmentConfig(DefaultConfig):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = CommonConfig.SESSION_COOKIE_NAME
     FLASK_ENV = "development"
 

--- a/config/envs/unit_testing.py
+++ b/config/envs/unit_testing.py
@@ -7,7 +7,7 @@ from fsd_utils import configclass
 @configclass
 class UnitTestingConfig(DefaultConfig):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = CommonConfig.SESSION_COOKIE_NAME
     FLASK_ENV = "unit_test"
 
@@ -27,7 +27,7 @@ class UnitTestingConfig(DefaultConfig):
     )
 
     AWS_ACCESS_KEY_ID = "test_access_id"
-    AWS_SECRET_ACCESS_KEY = "test_secret_key"
+    AWS_SECRET_ACCESS_KEY = "test_secret_key"  # pragma: allowlist secret
     AWS_REGION = "eu-west-2"
     AWS_PRIMARY_QUEUE_URL = "test_primary_url"
     AWS_SECONDARY_QUEUE_URL = "test_secondary_url"

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -90,7 +90,7 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'
     Export:

--- a/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
+++ b/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
@@ -85,9 +85,9 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       MasterUsername:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:username}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:username}}" ]]   # pragma: allowlist secret
       MasterUserPassword:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:password}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:password}}" ]]   # pragma: allowlist secret
       DatabaseName: !Ref fsdassessmentstoreclusterDBName
       Engine: 'aurora-postgresql'
       EngineVersion: '14.4'
@@ -126,11 +126,11 @@ Outputs:
     Value:
       !Sub
       - "postgres://${USERNAME}:${PASSWORD}@${HOSTNAME}:${PORT}/${DBNAME}"
-      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:username}}" ]]
-        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:password}}" ]]
-        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:host}}" ]]
-        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:port}}" ]]
-        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]
+      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:username}}" ]]  # pragma: allowlist secret
+        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
+        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:host}}" ]]  # pragma: allowlist secret
+        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:port}}" ]]  # pragma: allowlist secret
+        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdassessmentstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]  # pragma: allowlist secret
 
   fsdassessmentstoreclusterSecret: # injected as FSDAPPLICATIONSTORECLUSTER_SECRET environment variable by Copilot.
     Description: "The JSON secret that holds the database username and password. Fields are 'host', 'port', 'dbname', 'username', 'password', 'dbClusterIdentifier' and 'engine'"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,8 @@
 env =
     FLASK_ENV=unit_test
     FLASK_DEBUG=1
-    D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_assess_store
+# pragma: allowlist nextline secret
+D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_assess_store
 mocked-sessions=db.db.session
 
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,8 @@
 env =
     FLASK_ENV=unit_test
     FLASK_DEBUG=1
-# pragma: allowlist nextline secret
-D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_assess_store
+    # pragma: allowlist nextline secret
+    D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_assess_store
 mocked-sessions=db.db.session
 
 markers =


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Change description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugin `HexHighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 