### PR TITLE
add eager loading for flag updates on asessment flag table relationship

### DIFF
--- a/db/models/flags/assessment_flag.py
+++ b/db/models/flags/assessment_flag.py
@@ -45,4 +45,4 @@ class AssessmentFlag(BaseModel):
     sections_to_flag = db.Column(
         "sections_to_flag", ARRAY(db.String(256)), nullable=True
     )
-    updates = relationship("FlagUpdate")
+    updates = relationship("FlagUpdate", lazy="selectin")


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3468

In SQLAlchemy, when you retrieve an object using a query (such as db.session.scalar(statement) in your code), the default behavior is to load all attributes and relationships of that object eagerly unless you specify otherwise. So, in the code snippet, even though were using defer to defer loading of the jsonb_blob column, all other attributes and relationships of the AssessmentRecord object will still be loaded eagerly by default.

If the flag_update relationship is not a direct relationship to AssessmentRecord but is a relationship on another related object, such as Flag, it will not be loaded eagerly by default when you retrieve an AssessmentRecord object.

Eager loading vs Lazy loading

When to Use Each Approach:

Lazy Loading: Use lazy loading when you want to minimize initial query overhead, conserve resources, or when you need fine-grained control over when related data is loaded. Be cautious of N+1 query issues and optimize as needed.

Eager Loading: Use eager loading when you want to retrieve related data upfront to minimize database round trips, reduce N+1 query issues, or when you have complex queries that involve multiple joins. Eager loading is typically a better choice for performance-critical scenarios.

Specifying lazy="selectin" for the updates relationship in SQLAlchemy will change the loading behavior of the FlagUpdate objects related to the Flag objects within the AssessmentRecord. Here's what effect it will have:

Eager Loading: With lazy="selectin", the related FlagUpdate objects will be loaded eagerly when you access the updates relationship on a Flag object.

Reduced N+1 Query Issues: This loading strategy helps reduce N+1 query issues. In cases where you retrieve multiple Flag objects for an AssessmentRecord, and you subsequently access the updates relationship on each Flag object, SQLAlchemy will issue a single SQL query that fetches all the related FlagUpdate objects for those Flag objects, rather than issuing a separate SQL query for each FlagUpdate object. This can significantly improve query efficiency when dealing with multiple related objects.

Improved Query Performance: Eager loading with selectin can lead to improved query performance, especially when dealing with large datasets or deeply nested relationships.

Usage Considerations: While eager loading can optimize query performance, it's important to use it judiciously. Eager loading loads related data upfront, which may not be necessary for every use case. Be mindful of the potential impact on memory usage and query complexity.

Trade-offs: The trade-off of eager loading is that it may result in larger initial query payloads. If you access related data selectively, and not all FlagUpdate objects are needed in every scenario, you might want to consider the potential trade-offs between eager loading and lazy loading based on your application's requirements.