### PR TITLE
FS-3457 - Add ingress to DB to allow Bastion connectivity

### DIFF
--- a/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
+++ b/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
@@ -20,6 +20,9 @@ Mappings:
     All:
       "DBMinCapacity": 0.5 # AllowedValues: from 0.5 through 128
       "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
+  BastionMap:
+    test:
+      "SecurityGroup": "sg-0cf75a004dbade7b8"
 
 Resources:
   fsdassessmentstoreclusterDBSubnetGroup:
@@ -52,6 +55,11 @@ Resources:
           IpProtocol: tcp
           Description: !Sub 'From the Aurora Security Group of the workload ${Name}.'
           SourceSecurityGroupId: !Ref fsdassessmentstoreclusterSecurityGroup
+        - ToPort: 5432
+          FromPort: 5432
+          IpProtocol: tcp
+          Description: !Sub 'From the Bastion Security Group.'
+          SourceSecurityGroupId: !FindInMap [BastionMap, !Ref Env, 'SecurityGroup']
       VpcId:
         Fn::ImportValue:
           !Sub '${App}-${Env}-VpcId'


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3457

Change description
Add in Bastion's security group into the fsd-assessment-store DB's inbound rules.
Tested by using the aws ssm connection through bastion and being able to connect into the postgres DB.

[n/a] Unit tests and other appropriate tests added or updated
[n/a] README and other documentation has been updated / added (if needed)
 Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
How to test
If manual testing is needed, give suggested testing steps

Screenshots of UI changes (if applicable)