### PR TITLE
FS-3575: Add is_withdrawn flag and update queries

### DIFF
--- a/db/migrations/versions/~2023_10_04_1057-342b7a05b923_.py
+++ b/db/migrations/versions/~2023_10_04_1057-342b7a05b923_.py
@@ -1,0 +1,29 @@
+"""empty message
+
+Revision ID: 342b7a05b923
+Revises: 222a1c3b6321
+Create Date: 2023-10-04 10:57:01.282981
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "342b7a05b923"
+down_revision = "222a1c3b6321"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_withdrawn", sa.Boolean(), nullable=False, default=False
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.drop_column("is_withdrawn")

--- a/db/models/assessment_record/assessment_records.py
+++ b/db/models/assessment_record/assessment_records.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects.postgresql import TEXT
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import column_property
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import Boolean
 
 BaseModel: DefaultMeta = db.Model
 
@@ -77,6 +78,10 @@ class AssessmentRecord(BaseModel):
     qa_complete = relationship("QaComplete")
 
     location_json_blob = Column("location_json_blob", JSONB, nullable=True)
+
+    is_withdrawn = Column(
+        "is_withdrawn", Boolean, default=False, nullable=False
+    )
 
     # These are defined as column_properties not as hybrid_property due to performance
     # Using column_property below forces the json parsing to be done on the DB side which is quicker than in python


### PR DESCRIPTION
### Change description

- Adds a column `is_withdrawn` to assessment records, which acts as a flag to determine whether a record is marked as withdrawn
- The queries have been updated to not pull back any withdrawn applications, so we essentially "hide" it from the user interface
- This is done to match a support query to "withdraw" an application without losing the data, it would be good to have an option in the UI for this though to allow lead assessors to do this

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines