### PR TITLE
FS-3670 display `Not Provided` when none or empty string

### DIFF
--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -220,9 +220,9 @@ def format_add_another_component_contents(
             formatted_answers = (
                 [
                     (
-                        pre_frontend_formatter(answer)
-                        if (answer is not None or answer != "")
-                        else "Not Provided"  # default if None or empty string provided
+                        "Not Provided"  # default, if None or empty string provided
+                        if (answer is None or answer == "")
+                        else pre_frontend_formatter(answer)
                     )
                     for answer in answers
                 ]


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3670

### Description
Display `Not Provided` when none or empty string is provided

### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/127315890/4830a10a-db6b-49d3-8efa-234faa1c05d8)
