### PR TITLE
FS-3698 fix bug when None type found in formatted_answers

### DIFF
--- a/api/routes/subcriterias/get_sub_criteria.py
+++ b/api/routes/subcriterias/get_sub_criteria.py
@@ -242,7 +242,7 @@ def format_add_another_component_contents(
                 )
 
             # Manualy extract `ukAddressField` as text if rendered as dict
-            if column_config["type"] == "ukAddressField":
+            if column_config["type"] == "ukAddressField" and formatted_answers:
                 for ind, answer in enumerate(formatted_answers):
                     if isinstance(answer, dict):
                         try:


### PR DESCRIPTION
https://funding-service-design-team-dl.sentry.io/issues/4573667007/events/2c0d55f397a645b8bc1f612[…]=4504418765963264&referrer=alert-rule-issue-list
[FS-3698](https://dluhcdigital.atlassian.net/browse/FS-3698)

### Description
When partner organisations details are not provided, answers has `None` value. Refactored the code to include `None` checks



[FS-3698]: https://dluhcdigital.atlassian.net/browse/FS-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ