### PR TITLE
FS-3745 Adding assessor export config

### DIFF
--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -278,7 +278,37 @@ applicant_info_mapping = {
         },
     },
     DPIF_FUND_ID: {
-        "ASSESSOR_EXPORT": {},
+        "ASSESSOR_EXPORT": {
+            "form_fields": {
+                "nYJiWy": {"en": {"title": "Organisation name"}},
+                "uYsivE": {"en": {"title": "Project sponsor name"}},
+                "xgrxxv": {"en": {"title": "Project sponsor email"}},
+                "cPpwET": {"en": {"title": "Section 151 officer name"}},
+                "EMukio": {"en": {"title": "Section 151 officer email"}},
+                "AYmilW": {"en": {"title": "Lead contact name"}},
+                "IRugBv": {"en": {"title": "Lead contact email"}},
+                "JUgCya": {
+                    "en": {
+                        "title": "You have signed the Local Digital Declaration and agree to follow the 5 core principles"
+                    }
+                },
+                "vbmqwB": {
+                    "en": {
+                        "title": "Your section 151 officer consents to the funds being carried over and spent in the next financial year (March 2024-25) and beyond if deemed necessary in project budget planning"
+                    }
+                },
+                "EQffUz": {
+                    "en": {
+                        "title": "You agree to let all outputs from this work be published under open licence with a view to any organisation accessing, using or adopting them freely"
+                    }
+                },
+                "kPYiQE": {
+                    "en": {
+                        "title": "The information you have provided is accurate"
+                    }
+                },
+            }
+        },
         "OUTPUT_TRACKER": {},
     },
 }


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3745

### Change description
Adding config for the Export applicant information functionality 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Click the Export applicant information on DPIF


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/97108643/7eeb5927-415c-43c6-b8f0-acdc8b1ad9d2)
