### PR TITLE
FS-3815: Update dpif unscored criteria

### DIFF
--- a/config/mappings/dpif_mappping_parts/r2_unscored_criteria.py
+++ b/config/mappings/dpif_mappping_parts/r2_unscored_criteria.py
@@ -3,8 +3,8 @@
 
 unscored_sections = [
     {
-        "id": "about_your_organisation_and_future_work",
-        "name": "About your organisation and future work",
+        "id": "unscored",
+        "name": "Unscored",
         "sub_criteria": [
             {
                 "id": "about_your_organisation_and_future_work",


### PR DESCRIPTION
### Change description

Fix the unscored criteria config for dpif to allow assessment to display the "About your organisation and future work" flag

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Check the assessment frontend has the "About your organisation and future work" flag for dpif assessments


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/37579353/6fad3ecf-d336-4fe0-a9d7-c6c24bcfa90b)
