### PR TITLE
FS-3880 - Encrypt DBs

### DIFF
--- a/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
+++ b/copilot/fsd-assessment-store/addons/fsd-assessment-store-cluster.yml
@@ -108,6 +108,7 @@ Resources:
       DBClusterParameterGroupName: !Ref fsdassessmentstoreclusterDBClusterParameterGroup
       DBSubnetGroupName: !Ref fsdassessmentstoreclusterDBSubnetGroup
       Port: 5432
+      StorageEncrypted: true
       VpcSecurityGroupIds:
         - !Ref fsdassessmentstoreclusterDBClusterSecurityGroup
       ServerlessV2ScalingConfiguration:


### PR DESCRIPTION
FS-3880 - Change DB storage-at-rest to be encrypted as a result of PEN testing

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

NOTE: Deletes the database so data re-migration is required.