### PR TITLE
FS-3955 Adding Question to Unscored sections

### DIFF
--- a/config/mappings/cof_mapping_parts/r3w3_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/r3w3_unscored_sections.py
@@ -434,6 +434,13 @@ unscored_sections = [
                                 "question": "When you buy or lease a publicly owned asset, the public authority cannot transfer statutory services or duties to the community group.",
                             },
                             {
+                                "field_id": "JdEmqn",
+                                "form_name": "asset-information-cof-r3-w2",
+                                "field_type": "checkboxesField",
+                                "presentation_type": "list",
+                                "question": "Grants from this fund cannot be used to buy the freehold or premium on the lease of a publicly owned asset. Money must only be used for renovation and refurbishment costs",
+                            },
+                            {
                                 "field_id": "mZwrmI",
                                 "form_name": "asset-information-cof",
                                 "field_type": "yesNoField",


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3995

### Change description
Adding in question Grants from this fund cannot be used to buy the freehold or premium on the lease of a publicly owned asset. Money must only be used for renovation and refurbishment costs to unscored sections in Asset information under asset ownership

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Complete an application, then navigate to assessment. Click the Asset information sub criteria, The added question should be under Asset ownership


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/97108643/8c6837e6-10df-4ab0-bb57-a2b74d058303)

