### PR TITLE
FS-3279 filter null values in address field

### DIFF
--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -991,7 +991,14 @@ def get_export_data(
                             title = form_fields[field["key"]][language][
                                 "title"
                             ]
-                            answer = field["answer"]
+
+                            # filter 'null' values from the address field
+                            # TODO: Remove this filter after FS-4021
+                            if "organisation address" in title.lower():
+                                answer = field["answer"].replace(" null,", "")
+                            else:
+                                answer = field["answer"]
+
                             field_type = field["type"]
                             if field_type == "list" and not isinstance(
                                 answer, bool

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Dict
 from typing import List
 
+from bs4 import BeautifulSoup
 from db import db
 from db.models.assessment_record import AssessmentRecord
 from db.models.assessment_record import TagAssociation
@@ -1000,6 +1001,14 @@ def get_export_data(
                                 answer = field["answer"]
 
                             field_type = field["type"]
+                            if (
+                                field_type == "freeText"
+                            ):  # for `freeText` type, extract the plain text
+                                answer = BeautifulSoup(
+                                    answer, "html.parser"
+                                ).get_text(
+                                    strip=True
+                                )  # Extract text, strip extra whitespace
                             if field_type == "list" and not isinstance(
                                 answer, bool
                             ):  # Adding check for bool since yesno fields are considered lists


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3279
https://dluhcdigital.atlassian.net/browse/FS-3721

### Description
- Filter null values in the address field
- Extract plain text from `freeText` type and display in the exported application .

### Screenshots
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/127315890/081ac4a4-462a-48b4-8ed3-046fb74d4948)
![image](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/127315890/75869629-747b-43db-9ff7-1a9520170821)



