### PR TITLE
BAU: Make `get-stats` a bulk endpoint

### DIFF
--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,6 +1,7 @@
 from .assessment_routes import all_assessments_for_fund_round_id
 from .assessment_routes import assessment_metadata_for_application_id
 from .assessment_routes import assessment_stats_for_fund_round_id
+from .assessment_routes import assessment_stats_for_multiple_round_ids
 from .assessment_routes import get_all_uploaded_document_theme_answers
 from .assessment_routes import get_application_data_for_export
 from .assessment_routes import get_application_json
@@ -47,6 +48,7 @@ __all__ = [
     "get_banner_state",
     "get_progress_for_applications",
     "assessment_stats_for_fund_round_id",
+    "assessment_stats_for_multiple_round_ids",
     "post_progress_for_applications",
     "update_ar_status_to_completed",
     "get_application_json",

--- a/api/routes/assessment_routes.py
+++ b/api/routes/assessment_routes.py
@@ -35,6 +35,7 @@ from db.queries.qa_complete.queries import (
 )
 from db.queries.scores.queries import get_sub_criteria_to_latest_score_map
 from flask import current_app
+from flask import request
 
 
 def assessment_metadata_for_application_id(application_id: str) -> Dict:
@@ -180,6 +181,31 @@ def get_all_uploaded_document_theme_answers(application_id: str):
 def update_ar_status_to_completed(application_id: str):
     """Function updates the status to COMPLETE for the given application_id."""
     update_status_to_completed(application_id)
+
+
+def assessment_stats_for_multiple_round_ids(
+    fund_id: str,
+    search_term: str = "",
+    asset_type: str = "ALL",
+    status: str = "ALL",
+    search_in: str = "",
+    funding_type: str = "ALL",
+    countries: str = "all",
+):
+    round_ids = request.get_json().get("round_ids") or []
+    return {
+        round_id: assessment_stats_for_fund_round_id(
+            fund_id,
+            round_id,
+            search_term,
+            asset_type,
+            status,
+            search_in,
+            funding_type,
+            countries,
+        )
+        for round_id in round_ids
+    }
 
 
 def assessment_stats_for_fund_round_id(

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -153,82 +153,88 @@ paths:
                 type: array
                 items:
                   $ref: 'components.yml#/components/schemas/Assessment'
-  '/assessments/get-stats/{fund_id}/{round_id}':
-    parameters:
-      - name: fund_id
-        in: path
+  '/assessments/get-stats/{fund_id}':
+    post:
+      parameters:
+        - name: fund_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: path
+        - name: search_term
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+        - name: asset_type
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+        - name: status
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+        - name: search_in
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+        - name: funding_type
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+        - name: countries
+          in: query
+          style: form
+          schema:
+            type: string
+            format: query
+          required: false
+          explode: true
+      requestBody:
         required: true
-        schema:
-          type: string
-          format: path
-      - name: round_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: path
-      - name: search_term
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-      - name: asset_type
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-      - name: status
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-      - name: search_in
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-      - name: funding_type
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-      - name: countries
-        in: query
-        style: form
-        schema:
-          type: string
-          format: query
-        required: false
-        explode: true
-    get:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                round_ids:
+                  type: array
+                  items:
+                    type: string
       tags:
         - assessments
-      summary: Get assessment stats
-      description: Get a selection of required metrics
-      operationId: api.routes.assessment_stats_for_fund_round_id
+      summary: Get assessment stats for multiple rounds
+      description: Get a selection of required metrics for multiple rounds
+      operationId: api.routes.assessment_stats_for_multiple_round_ids
       responses:
         200:
-          description: SUCCESS - A collection of assessment metrics
+          description: SUCCESS - A mapping of round_id to a collection of assessment metrics
           content:
             application/json:
               schema:
                 type: object
-                $ref: 'components.yml#/components/schemas/AssessmentsStats'
+                additionalProperties:
+                  $ref: 'components.yml#/components/schemas/AssessmentsStats'
   '/assessments/get-team-flag-stats/{fund_id}/{round_id}':
     parameters:
       - name: fund_id

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -38,12 +38,14 @@ def test_get_assessments_stats(client, seed_application_records):
     # Get test applications
     applications = client.get(f"/application_overviews/{fund_id}/{round_id}").json
 
-    assessment_stats = client.get(f"/assessments/get-stats/{fund_id}/{round_id}").json
+    request = client.post(f"/assessments/get-stats/{fund_id}", json={"round_ids": [round_id]})
+    assessment_stats = request.json.get(round_id)
     assert assessment_stats["qa_completed"] == 0
 
     create_qa_complete_record(applications[0]["application_id"], "usera")
 
-    assessment_stats = client.get(f"/assessments/get-stats/{fund_id}/{round_id}").json
+    request = client.post(f"/assessments/get-stats/{fund_id}", json={"round_ids": [round_id]})
+    assessment_stats = request.json.get(round_id)
     assert assessment_stats["qa_completed"] == 1
 
     create_qa_complete_record(applications[1]["application_id"], "usera")
@@ -57,7 +59,8 @@ def test_get_assessments_stats(client, seed_application_records):
         allocation="Assessor",
     ).id
 
-    assessment_stats = client.get(f"/assessments/get-stats/{fund_id}/{round_id}").json
+    request = client.post(f"/assessments/get-stats/{fund_id}", json={"round_ids": [round_id]})
+    assessment_stats = request.json.get(round_id)
     assert assessment_stats["flagged"] == 1
     assert assessment_stats["qa_completed"] == 1
 
@@ -69,7 +72,8 @@ def test_get_assessments_stats(client, seed_application_records):
         assessment_flag_id=flag_id,
     )
 
-    assessment_stats = client.get(f"/assessments/get-stats/{fund_id}/{round_id}").json
+    request = client.post(f"/assessments/get-stats/{fund_id}", json={"round_ids": [round_id]})
+    assessment_stats = request.json.get(round_id)
 
     assert assessment_stats["flagged"] == 0
     assert assessment_stats["qa_completed"] == 2


### PR DESCRIPTION
### Change description

- Change how the `get-stats` endpoint works, now takes `round_ids` as a post body
- Now returns a dictionary of `round_id` to `assessment_stats` basically

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

![localhost_3005_ (1)](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/117724519/759ce9b4-52a4-4c09-b904-aa07b604311e)

