### PR TITLE
BAU: Re-add old API endpoint for seamless deployment

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -235,6 +235,83 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: 'components.yml#/components/schemas/AssessmentsStats'
+# TODO: Remove old API endpoint once the new endpoint is fully deployed and confirmed stable. Ensure all frontend services are updated to utilize the new endpoint before removal.
+  '/assessments/get-stats/{fund_id}/{round_id}':
+    parameters:
+      - name: fund_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: path
+      - name: round_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: path
+      - name: search_term
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+      - name: asset_type
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+      - name: status
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+      - name: search_in
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+      - name: funding_type
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+      - name: countries
+        in: query
+        style: form
+        schema:
+          type: string
+          format: query
+        required: false
+        explode: true
+    get:
+      tags:
+        - assessments
+      summary: Get assessment stats
+      description: Get a selection of required metrics
+      operationId: api.routes.assessment_stats_for_fund_round_id
+      responses:
+        200:
+          description: SUCCESS - A collection of assessment metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: 'components.yml#/components/schemas/AssessmentsStats'
   '/assessments/get-team-flag-stats/{fund_id}/{round_id}':
     parameters:
       - name: fund_id


### PR DESCRIPTION
### Change description

This change reintroduces the previously deprecated API endpoint to ensure backward compatibility and uninterrupted service during the transition period of deploying frontend and backend updates separately. By maintaining both the old and new endpoints, we prevent potential downtime or accessibility issues for users.

### Screenshots of UI changes (if applicable)

![localhost_3005_ (2)](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/117724519/03cd1e24-eb90-48e8-bb26-19ddac8c38ba)
