### PR TITLE
FS-4249-extra-s-in-about-your-assset-sub-criteria

### DIFF
--- a/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
@@ -74,7 +74,7 @@ unscored_sections = [
                     },
                     {
                         "id": "about-your-asset",
-                        "name": "About your assset",
+                        "name": "About your asset",
                         "answers": [
                             {
                                 "field_id": "eEaDGz",

--- a/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
@@ -61,7 +61,7 @@ unscored_sections = [
                                 "form_name": "organisation-details",
                                 "field_type": "radiosField",
                                 "presentation_type": "text",
-                                "question": "How is you organisation classified",
+                                "question": "How your organisation is classified",
                             },
                             {
                                 "field_id": "NcQSbU",


### PR DESCRIPTION
### Ticket
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4249
https://dluhcdigital.atlassian.net/browse/FS-4267

### Description

- remove extra s from "About your asset" sub criteria
- Correct the question to "How your organisation is classified" from "How is you organisation classified"

### Screenshots of UI changes 
![Screenshot 2024-03-06 at 14 55 46](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/80714392/cefc1b1b-3d36-407d-9fb0-ac6a8366a062)

![Screenshot 2024-03-06 at 15 26 30](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/80714392/8a8a3cf8-2c64-4719-9b5c-2293e0e7d890)

