### PR TITLE
 FS-4259-missing-welsh-column-translation-added-for-csv-file

### DIFF
--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -342,8 +342,8 @@ applicant_info_mapping = {
                 "cPcZos": {
                     "en": {"title": "Do you already own the asset?", "field_type": "yesNoField"},
                     "cy": {
-                        "title": "",
-                        "field_type": "",
+                        "title": "A ydych eisoes yn berchen ar yr ased?",
+                        "field_type": "yesNoField",
                     },
                 },
                 "jOpXfi": {


### PR DESCRIPTION
### Ticket
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4259

### Description 
Added translation: Missing column header in " Export applicant information" for Welsh EOI applications. "Do you already own the asset?"



### Screenshots of UI changes 
Before
![Screenshot 2024-03-14 at 15 41 13](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/80714392/7c36ca56-79d9-4aa2-abf7-a36b6f70332b)


After
![Screenshot 2024-03-14 at 15 37 03](https://github.com/communitiesuk/funding-service-design-assessment-store/assets/80714392/77aa8e1b-99f0-4297-bfc1-719a09a27149)

