### PR TITLE
Revert "Bump connexion from 2.14.2 to 3.0.6 (#424)"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,19 +11,10 @@ alembic==1.9.4
     #   flask-migrate
 alembic-utils==0.8.2
     # via -r requirements.txt
-anyio==4.3.0
-    # via
-    #   -r requirements.txt
-    #   httpx
-    #   starlette
 apscheduler==3.10.4
     # via
     #   -r requirements.txt
     #   flask-apscheduler
-asgiref==3.7.2
-    # via
-    #   -r requirements.txt
-    #   connexion
 async-timeout==4.0.2
     # via
     #   -r requirements.txt
@@ -65,8 +56,6 @@ cachetools==4.2.4
 certifi==2023.7.22
     # via
     #   -r requirements.txt
-    #   httpcore
-    #   httpx
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -87,15 +76,20 @@ click==8.1.3
     # via
     #   -r requirements.txt
     #   black
+    #   clickclick
     #   flask
     #   pip-tools
+clickclick==20.10.2
+    # via
+    #   -r requirements.txt
+    #   connexion
 colored==1.4.4
     # via -r requirements-dev.in
 commonmark==0.9.1
     # via
     #   -r requirements.txt
     #   rich
-connexion==3.0.6
+connexion==2.14.2
     # via -r requirements.txt
 cryptography==42.0.4
     # via
@@ -122,6 +116,7 @@ flake8-pyproject==1.2.3
 flask==2.2.5
     # via
     #   -r requirements.txt
+    #   connexion
     #   flask-apscheduler
     #   flask-babel
     #   flask-migrate
@@ -167,25 +162,11 @@ gunicorn==20.1.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-h11==0.14.0
-    # via
-    #   -r requirements.txt
-    #   httpcore
-httpcore==1.0.4
-    # via
-    #   -r requirements.txt
-    #   httpx
-httpx==0.27.0
-    # via
-    #   -r requirements.txt
-    #   connexion
 identify==2.5.8
     # via pre-commit
 idna==3.4
     # via
     #   -r requirements.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -198,11 +179,11 @@ invoke==1.7.3
 itsdangerous==2.1.2
     # via
     #   -r requirements.txt
+    #   connexion
     #   flask
 jinja2==3.1.2
     # via
     #   -r requirements.txt
-    #   connexion
     #   flask
     #   flask-babel
     #   swagger-ui-bundle
@@ -273,6 +254,7 @@ packaging==21.3
     # via
     #   -r requirements.txt
     #   build
+    #   connexion
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   prance
@@ -365,10 +347,6 @@ python-json-logger==2.0.4
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-python-multipart==0.0.9
-    # via
-    #   -r requirements.txt
-    #   connexion
 pytz==2022.6
     # via
     #   -r requirements.txt
@@ -379,6 +357,7 @@ pytz==2022.6
 pyyaml==6.0
     # via
     #   -r requirements.txt
+    #   clickclick
     #   connexion
     #   funding-service-design-utils
     #   jsonschema-path
@@ -441,11 +420,6 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
     #   thrift
-sniffio==1.3.1
-    # via
-    #   -r requirements.txt
-    #   anyio
-    #   httpx
 soupsieve==2.5
     # via
     #   -r requirements.txt
@@ -462,10 +436,6 @@ sqlalchemy-utils==0.41.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-starlette==0.37.2
-    # via
-    #   -r requirements.txt
-    #   connexion
 stringcase==1.2.0
     # via
     #   -r requirements.txt
@@ -480,7 +450,6 @@ typing-extensions==4.4.0
     # via
     #   -r requirements.txt
     #   alembic-utils
-    #   connexion
     #   flupy
     #   sqlalchemy
 tzlocal==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,14 +10,8 @@ alembic==1.9.4
     #   flask-migrate
 alembic-utils==0.8.2
     # via -r requirements.in
-anyio==4.3.0
-    # via
-    #   httpx
-    #   starlette
 apscheduler==3.10.4
     # via flask-apscheduler
-asgiref==3.7.2
-    # via connexion
 async-timeout==4.0.2
     # via redis
 attrs==23.1.0
@@ -40,8 +34,6 @@ cachetools==4.2.4
     # via flipper-client
 certifi==2023.7.22
     # via
-    #   httpcore
-    #   httpx
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -51,10 +43,14 @@ chardet==4.0.0
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3
-    # via flask
+    # via
+    #   clickclick
+    #   flask
+clickclick==20.10.2
+    # via connexion
 commonmark==0.9.1
     # via rich
-connexion==3.0.6
+connexion==2.14.2
     # via -r requirements.in
 cryptography==42.0.4
     # via pyjwt
@@ -65,6 +61,7 @@ decorator==5.1.1
 flask==2.2.5
     # via
     #   -r requirements.in
+    #   connexion
     #   flask-apscheduler
     #   flask-babel
     #   flask-migrate
@@ -97,24 +94,16 @@ greenlet==3.0.1
     # via sqlalchemy
 gunicorn==20.1.0
     # via funding-service-design-utils
-h11==0.14.0
-    # via httpcore
-httpcore==1.0.4
-    # via httpx
-httpx==0.27.0
-    # via connexion
 idna==3.4
-    # via
-    #   anyio
-    #   httpx
-    #   requests
+    # via requests
 inflection==0.5.1
     # via connexion
 itsdangerous==2.1.2
-    # via flask
-jinja2==3.1.2
     # via
     #   connexion
+    #   flask
+jinja2==3.1.2
+    # via
     #   flask
     #   flask-babel
     #   swagger-ui-bundle
@@ -157,6 +146,7 @@ openapi-spec-validator==0.7.1
     # via -r requirements.in
 packaging==21.3
     # via
+    #   connexion
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   prance
@@ -195,8 +185,6 @@ python-dotenv==0.20.0
     # via funding-service-design-utils
 python-json-logger==2.0.4
     # via funding-service-design-utils
-python-multipart==0.0.9
-    # via connexion
 pytz==2022.6
     # via
     #   apscheduler
@@ -205,6 +193,7 @@ pytz==2022.6
     #   funding-service-design-utils
 pyyaml==6.0
     # via
+    #   clickclick
     #   connexion
     #   funding-service-design-utils
     #   jsonschema-path
@@ -250,10 +239,6 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
     #   thrift
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
 soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.23
@@ -268,8 +253,6 @@ sqlalchemy-utils==0.41.1
     # via
     #   -r requirements.in
     #   funding-service-design-utils
-starlette==0.37.2
-    # via connexion
 stringcase==1.2.0
     # via dataclass-dict-convert
 swagger-ui-bundle==1.1.0
@@ -279,7 +262,6 @@ thrift==0.16.0
 typing-extensions==4.4.0
     # via
     #   alembic-utils
-    #   connexion
     #   flupy
     #   sqlalchemy
 tzlocal==5.0.1


### PR DESCRIPTION
This reverts commit e62def61fc70f91c23601361efd97e148e2352e9.


### Description
- Issues with connexion 3.0.6 (so far failed unit tests are noticed)
- Reverting back the changes
- created a ticket https://dluhcdigital.atlassian.net/browse/FS-4302 to keep track of this issue