### PR TITLE
FS-4250: Fix about your asset COF EOI config

### DIFF
--- a/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
+++ b/config/mappings/cof_mapping_parts/eoi_unscored_sections.py
@@ -135,7 +135,7 @@ unscored_sections = [
                             {
                                 "field_id": "XuAyrs",
                                 "form_name": "about-your-asset",
-                                "field_type": "yesNoField",
+                                "field_type": "radiosField",
                                 "presentation_type": "text",
                                 "question": "Does the asset belong to a public authority?",
                             },


### PR DESCRIPTION
### Change description

- `XuAyrs` is a `RadiosField` ([see here](https://github.com/communitiesuk/digital-form-builder/blob/792cef36b685f735e6fdd8c9f669e52fc387c630/fsd_config/form_jsons/cof/eoi/cy/ynglyn-ach-ased.json#L272-L276))
- Mark as a `radiosField` so we format it correctly, it's not a `yesNoField`
