### PR TITLE
Fs 4315 cof export

### DIFF
--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -310,7 +310,10 @@ applicant_info_mapping = {
                     "cy": {"title": "Cod post o ased", "field_type": "uk_postcode"},
                 },
                 "ABROnB": {"en": {"title": "Capital funding request"}, "cy": {"title": "Cais cyllido cyfalaf"}},
-                "tSKhQQ": {"en": {"title": "Revenue costs (optional)"}, "cy": {"title": "Costau refeniw (dewisol)"}},
+                "tSKhQQ": {
+                    "en": {"title": "Revenue costs (optional)", "field_type": "sum_list", "field_to_sum": "UyaAHw"},
+                    "cy": {"title": "Costau refeniw (dewisol)"},
+                },
                 "apGjFS": {"en": {"title": "Project name"}, "cy": {"title": "Enw'r prosiect"}},
             }
         },

--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -277,6 +277,41 @@ applicant_info_mapping = {
                         "field_type": "ukAddressField",
                     },
                 },
+                "WWWWxy": {
+                    "en": {"title": "Your expression of interest (EOI) application reference"},
+                    "cy": {"title": "Cyfeirnod eich ffurflen mynegi diddordeb (EOI)."},
+                },
+                "YdtlQZ": {"en": {"title": "Organisation name"}, "cy": {"title": "Enw'r sefydliad"}},
+                "lajFtB": {
+                    "en": {
+                        "title": "Type of organisation",
+                        "field_type": "radiosField",
+                    },
+                    "cy": {
+                        "title": "Math o sefydliad",
+                        "field_type": "radiosField",
+                    },
+                },
+                "aHIGbK": {"en": {"title": "Charity number"}, "cy": {"title": "Rhif elusen"}},
+                "GlPmCX": {"en": {"title": "Company registration number"}, "cy": {"title": "Rhif cofrestru'r cwmni"}},
+                "oXGwlA": {
+                    "en": {
+                        "title": "Asset type",
+                        "field_type": "radiosField",
+                    },
+                    "cy": {
+                        "title": "Math o ased",
+                        "field_type": "radiosField",
+                    },
+                },
+                "aJGyCR": {"en": {"title": "Type of asset (other)"}, "cy": {"title": "Math o eiddo (arall)"}},
+                "EfdliG": {
+                    "en": {"title": "Postcode of asset", "field_type": "uk_postcode"},
+                    "cy": {"title": "Cod post o ased", "field_type": "uk_postcode"},
+                },
+                "ABROnB": {"en": {"title": "Capital funding request"}, "cy": {"title": "Cais cyllido cyfalaf"}},
+                "tSKhQQ": {"en": {"title": "Revenue costs (optional)"}, "cy": {"title": "Costau refeniw (dewisol)"}},
+                "apGjFS": {"en": {"title": "Project name"}, "cy": {"title": "Enw'r prosiect"}},
             }
         },
         "OUTPUT_TRACKER": {},

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -874,6 +874,8 @@ def get_export_data(
                             if field["answer"] and field_type == "ukAddressField":
                                 address_parts = field["answer"].split(", ")
                                 answer = ", ".join([part for part in address_parts if part != "null"])
+                            elif field["answer"] and field_type == "uk_postcode":
+                                answer = field["answer"].split(", ")[-1]
                             else:
                                 answer = field["answer"]
 

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -887,6 +887,16 @@ def get_export_data(
                                 answer, bool
                             ):  # Adding check for bool since yesno fields are considered lists
                                 answer = format_lists(answer)
+
+                            if field_type == "sum_list" and isinstance(field["answer"], list):
+                                answer = 0
+                                field_to_sum = form_fields[field["key"]][language].get("field_to_sum", None)
+                                if not field_to_sum:
+                                    applicant_info[title] = ""
+                                    continue
+                                for sum_item in field["answer"]:
+                                    answer += int(sum_item[field_to_sum])
+
                             applicant_info[title] = answer
             applicant_info = add_missing_elements_with_empty_values(applicant_info, form_fields, language)
         final_list.append(applicant_info)

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -1,9 +1,13 @@
 import inspect
+import sys
 
-from invoke import task
-from tasks.helper_tasks import _echo_input
-from tasks.helper_tasks import _echo_print
-from tasks.helper_tasks import _env_var
+sys.path.insert(1, ".")
+
+from invoke import task  # noqa:E402
+from tasks.helper_tasks import _echo_input  # noqa:E402
+from tasks.helper_tasks import _echo_print  # noqa:E402
+from tasks.helper_tasks import _env_var  # noqa:E402
+from app import app  # noqa:E402
 
 # Needed for invoke to work on python3.11
 # Remove once invoke has been updated.
@@ -23,7 +27,7 @@ def bootstrap_dev_db(c):
     from sqlalchemy_utils.functions import database_exists
 
     with _env_var("FLASK_ENV", "development"):
-        from app import app
+        # from app import app
 
         with app.app_context():
             from config import Config
@@ -66,7 +70,7 @@ def seed_dev_db(c, fundround=None, appcount=None):
     from flask_migrate import upgrade
 
     with _env_var("FLASK_ENV", "development"):
-        from app import app
+        # from app import app
 
         with app.app_context():
             from tests._helpers import seed_database_for_fund_round

--- a/tasks/db_tasks.py
+++ b/tasks/db_tasks.py
@@ -27,8 +27,6 @@ def bootstrap_dev_db(c):
     from sqlalchemy_utils.functions import database_exists
 
     with _env_var("FLASK_ENV", "development"):
-        # from app import app
-
         with app.app_context():
             from config import Config
 
@@ -70,8 +68,6 @@ def seed_dev_db(c, fundround=None, appcount=None):
     from flask_migrate import upgrade
 
     with _env_var("FLASK_ENV", "development"):
-        # from app import app
-
         with app.app_context():
             from tests._helpers import seed_database_for_fund_round
             from config import Config

--- a/tests/test_data/hand-crafted-apps.json
+++ b/tests/test_data/hand-crafted-apps.json
@@ -5159,20 +5159,42 @@
             "status": "COMPLETED",
             "category": "bgUGuD",
             "question": "Unsecured match funding"
-          },
-          {
-            "index": 0,
+          },{
+            "category": "bgUGuD",
             "fields": [
               {
+                "answer": true,
                 "key": "matkNH",
-                "type": "list",
                 "title": "Are you applying for revenue funding from the Community Ownership Fund? (optional)",
-                "answer": false
+                "type": "list"
               }
             ],
-            "status": "COMPLETED",
+            "index": 0,
+            "question": "Revenue funding",
+            "status": "COMPLETED"
+          },
+          {
             "category": "bgUGuD",
-            "question": "Revenue funding"
+            "fields": [
+              {
+                "answer": [
+                  {
+                    "UyaAHw": 234,
+                    "hGsUaZ": "asdf"
+                  },
+                  {
+                    "UyaAHw": 222,
+                    "hGsUaZ": "two"
+                  }
+                ],
+                "key": "tSKhQQ",
+                "title": "Revenue costs (optional)",
+                "type": "multiInput"
+              }
+            ],
+            "index": 0,
+            "question": "Revenue costs (optional)",
+            "status": "COMPLETED"
           },
           {
             "fields": [

--- a/tests/test_data/hand-crafted-apps.json
+++ b/tests/test_data/hand-crafted-apps.json
@@ -4090,5 +4090,2613 @@
     "last_edited": "2023-06-12T13:19:34.332308",
     "project_name": "Night shelter project",
     "date_submitted": "2023-06-12T13:19:38.752573"
+  },
+  {
+    "id": "feffcfed-363b-449f-b0c2-8661d56fd911",
+    "forms": [
+      {
+        "name": "community-use-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "zTcrYo",
+                "type": "freeText",
+                "title": "Who in the community currently uses the asset, or has used it in the past?",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "whlRYS",
+                "type": "freeText",
+                "title": "Tell us how losing the asset would affect, or has already affected, people in the community",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "NGSXHE",
+                "type": "freeText",
+                "title": "Why will the asset be lost without community intervention?",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "Ieudgn",
+                "type": "freeText",
+                "title": "Explain how the community will be better served with the asset under community ownership",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "GMkooI",
+            "question": "Who uses the asset"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "environmental-sustainability-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "dypuJs",
+                "type": "freeText",
+                "title": "Tell us how you have considered the environmental sustainability of your project",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "ljcxPd",
+            "question": "How you've considered the environment"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "applicant-information-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "SnLGJE",
+                "type": "text",
+                "title": "Name of lead contact",
+                "answer": "test lead person"
+              },
+              {
+                "key": "qRDTUc",
+                "type": "text",
+                "title": "Lead contact job title",
+                "answer": "test"
+              },
+              {
+                "key": "NlHSBg",
+                "type": "text",
+                "title": "Lead contact email address",
+                "answer": "test@test.com"
+              },
+              {
+                "key": "FhBkJQ",
+                "type": "text",
+                "title": "Lead contact telephone number",
+                "answer": "1554323256554"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "ZuHuGk",
+            "question": "Lead contact details"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "local-support-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "tDVPnl",
+                "type": "freeText",
+                "title": "Tell us about the local support for your project",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "bDWjTN",
+                "type": "text",
+                "title": "Upload supporting evidence (optional)",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "apkBSm",
+            "question": "Your support for the project"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "risk-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "EODncR",
+                "type": "text",
+                "title": "Risks to your project (document upload)",
+                "answer": "TestDoc.docx"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "HKdODf",
+            "question": "Your project risk register"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "upload-business-plan-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ndpQJk",
+                "type": "text",
+                "title": "Upload business plan",
+                "answer": "TestDoc.docx"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "xtwqlH",
+            "question": "Your business plan"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "organisation-information-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "WWWWxy",
+                "type": "text",
+                "title": "Your unique tracker number",
+                "answer": "45634564"
+              },
+              {
+                "key": "YdtlQZ",
+                "type": "text",
+                "title": "Organisation name",
+                "answer": "Test"
+              },
+              {
+                "key": "iBCGxY",
+                "type": "list",
+                "title": "Does your organisation use any other names?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Organisation names"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "PHFkCs",
+                "type": "text",
+                "title": "Alternative names of your organisation",
+                "answer": "Test"
+              },
+              {
+                "key": "QgNhXX",
+                "type": "text",
+                "title": "Alternative names of your organisation - Alternative name 2 ",
+                "answer": null
+              },
+              {
+                "key": "XCcqae",
+                "type": "text",
+                "title": "Alternative names of your organisation - Alternative name 3 ",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Alternative names of your organisation"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "emVGxS",
+                "type": "freeText",
+                "title": "What is your organisation's main purpose?",
+                "answer": "\u003Cp\u003ETest\u003C/p\u003E"
+              },
+              {
+                "key": "btTtIb",
+                "type": "freeText",
+                "title": "Tell us about your organisation's main activities",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "SkocDi",
+                "type": "freeText",
+                "title": "Tell us about your organisation's main activities - Activity 2 ",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "CNeeiC",
+                "type": "freeText",
+                "title": "Tell us about your organisation's main activities - Activity 3 ",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "BBlCko",
+                "type": "list",
+                "title": "Have you delivered projects like this before?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Purpose and activities"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "wxCszQ",
+                "type": "freeText",
+                "title": "Describe your previous projects",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "QJFQgi",
+                "type": "freeText",
+                "title": "Describe your previous projects - Project 2 ",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "DGNWqE",
+                "type": "freeText",
+                "title": "Describe your previous projects - Project 3 ",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Previous projects similar to this one"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "lajFtB",
+                "type": "list",
+                "title": "Type of organisation",
+                "answer": "CIO"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "How your organisation is classified"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "aHIGbK",
+                "type": "text",
+                "title": "Charity number ",
+                "answer": "786786"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Charity registration details"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "DwfHtk",
+                "type": "list",
+                "title": "Is your organisation a trading subsidiary of a parent company?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Trading subsidiaries"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ZQolYb",
+                "type": "text",
+                "title": "Organisation address",
+                "answer": "test, test, test, test, ss12ss"
+              },
+              {
+                "key": "zsoLdf",
+                "type": "list",
+                "title": "Is your correspondence address different to the organisation address?",
+                "answer": true
+              },
+              {
+                "key": "FhbaEy",
+                "type": "text",
+                "title": "Website and social media",
+                "answer": "https://www.google.com"
+              },
+              {
+                "key": "FcdKlB",
+                "type": "text",
+                "title": "Website and social media - Link or username 2",
+                "answer": null
+              },
+              {
+                "key": "BzxgDA",
+                "type": "text",
+                "title": "Website and social media - Link or username 3",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Organisation address"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "VhkCbM",
+                "type": "text",
+                "title": "Correspondence address",
+                "answer": "Test, test, test, test, ss12ss"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Correspondence address"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "hnLurH",
+                "type": "list",
+                "title": "Is your application a joint bid in partnership with other organisations?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Joint applications"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "asset-information-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "oXGwlA",
+                "type": "list",
+                "title": "Asset type",
+                "answer": "community-centre"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "How the asset is used in the community"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "LaxeJN",
+                "type": "list",
+                "title": "How do you intend to take community ownership of the asset?",
+                "answer": "buy-the-asset"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "The asset in community ownership"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "tTOrEp",
+                "type": "text",
+                "title": "Please upload evidence that shows the asset valuation (if you are buying the asset) or the lease agreement (if you are leasing the asset).",
+                "answer": "TestDoc.docx"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Upload asset valuation or lease agreement"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "wAUFqr",
+                "type": "list",
+                "title": "Do you know who currently owns your asset?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Who owns the asset"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XiHjDO",
+                "type": "text",
+                "title": "Tell us what you know about the sale or lease of the asset",
+                "answer": "test"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Current ownership status"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XPcbJx",
+                "type": "freeText",
+                "title": "Describe the expected sale process, or the proposed terms of your lease if you are planning to rent the asset",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "jGjScT",
+                "type": "date",
+                "title": "Expected date of sale or lease",
+                "answer": "2020-12-11"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Expected terms of your ownership or lease"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "VGXXyq",
+                "type": "list",
+                "title": "Is your asset currently publicly owned?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Public ownership"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qlqyUq",
+                "type": "list",
+                "title": "Why is the asset at risk of closure?",
+                "answer": [
+                  "Closure"
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Risk of closure"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "iqnlTk",
+                "type": "list",
+                "title": "Is this a registered Asset of Community Value (ACV)?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Assets of community value"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "mZwrmI",
+                "type": "list",
+                "title": "Are there assets or services of a similar type available locally?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "BfgLCc",
+                "type": "list",
+                "title": "Is your asset different from what is available locally?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "WTZoVD",
+                "type": "freeText",
+                "title": "Tell us how and why your asset or the service is different",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "GEJNWF",
+                "type": "freeText",
+                "title": "How accessible is the closest asset or service?",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "CFFsxV",
+                "type": "list",
+                "title": "Does part of your project include a commercial aspect?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "FDZQTQ",
+                "type": "freeText",
+                "title": "Tell us how the commercial aspect relates to the other services you provide",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Local service provision"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "project-information-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "pWwCRM",
+                "type": "list",
+                "title": "Have you applied to the Community Ownership Fund before?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Previous Community Ownership Fund applications"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "apGjFS",
+                "type": "text",
+                "title": "Project name",
+                "answer": "Test Project"
+              },
+              {
+                "key": "bEWpAj",
+                "type": "freeText",
+                "title": "Tell us how the asset is currently being used, or how it has been used before, and why it's important to the community",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "uypCNM",
+                "type": "freeText",
+                "title": "Give a brief summary of your project, including what you hope to achieve",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "AgeRbd",
+                "type": "freeText",
+                "title": "Tell us about the planned activities and/or services that will take place in the asset",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Project name and summary"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "EfdliG",
+                "type": "text",
+                "title": "Address of the community asset",
+                "answer": "test, test, test, test, NP10 8QQ"
+              },
+              {
+                "key": "fIEUcb",
+                "type": "text",
+                "title": " In which constituency is your asset?",
+                "answer": "test"
+              },
+              {
+                "key": "SWfcTo",
+                "type": "text",
+                "title": "In which local council area is your asset?",
+                "answer": "test"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Address of the asset"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "community-engagement-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "azCutK",
+                "type": "freeText",
+                "title": "Tell us how you have engaged with the community about your intention to take ownership of the asset",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "How you've engaged with the community"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "jAhuWN",
+                "type": "freeText",
+                "title": "Describe your fundraising activities",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "Your fundraising activities"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "HYsezC",
+                "type": "freeText",
+                "title": "Tell us about any partnerships you've formed, and how they'll help the project be successful",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "GGBgBY",
+                "type": "freeText",
+                "title": "Tell us how your project supports any wider local plans",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "Partnerships and local plans"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "declarations-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "vSQKwD",
+                "type": "list",
+                "title": "Confirm you have considered subsidy control and state aid implications for your project, and the information you have given us is correct",
+                "answer": true
+              },
+              {
+                "key": "CQoLFp",
+                "type": "list",
+                "title": "Confirm you have considered people with protected characteristics throughout the planning of your project",
+                "answer": true
+              },
+              {
+                "key": "jdPkiX",
+                "type": "list",
+                "title": "Confirm you have considered sustainability and the environment throughout the planning of your project, including compliance with the government's Net Zero ambitions",
+                "answer": true
+              },
+              {
+                "key": "qWuSCy",
+                "type": "list",
+                "title": "Confirm you have a bank account set up and associated with the organisation you are applying on behalf of",
+                "answer": true
+              },
+              {
+                "key": "tjZlml",
+                "type": "list",
+                "title": "Confirm that the information you've provided in this application is accurate to the best of your knowledge on the date of submission",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "LkvizC",
+            "question": "Agree to the final confirmations"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "community-benefits-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "pqYxJO",
+                "type": "list",
+                "title": "What community benefits do you expect to deliver with this project?",
+                "answer": [
+                  "community-pride"
+                ]
+              },
+              {
+                "key": "lgfiGB",
+                "type": "freeText",
+                "title": "Tell us about these benefits in detail, and how the asset's activities will help deliver them",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "zKKouR",
+                "type": "freeText",
+                "title": "Explain how you plan to deliver and sustain these benefits over time",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "ZyIQGI",
+                "type": "freeText",
+                "title": "Tell us how you'll make sure the whole community benefits from the asset",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "PTOBPV",
+            "question": "Benefits you'll deliver"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "funding-required-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ABROnB",
+                "type": "text",
+                "title": "Capital funding request",
+                "answer": "966585"
+              },
+              {
+                "key": "hJkmBS",
+                "type": "list",
+                "title": "If successful, will you use your funding in the next 12 months?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Capital funding request"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qQLyXL",
+                "type": "multiInput",
+                "title": "Capital costs",
+                "answer": [
+                  {
+                    "GLQlOh": "test",
+                    "JtwkMy": 542,
+                    "LeTLDo": 456,
+                    "pHZDWT": 45654
+                  }
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Capital costs for your project"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "DOvZvB",
+                "type": "list",
+                "title": "Have you secured any match funding yet?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "If you've secured match funding"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "vEOdBS",
+                "type": "multiInput",
+                "title": "Unsecured match funding",
+                "answer": [
+                  {
+                    "THOdae": 41242,
+                    "iMJdfs": "test"
+                  }
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Unsecured match funding"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "matkNH",
+                "type": "list",
+                "title": "Are you applying for revenue funding from the Community Ownership Fund? (optional)",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Revenue funding"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "feasibility-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "iSbwDM",
+                "type": "freeText",
+                "title": "Tell us about the feasibility studies you have carried out for your project",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "jFPlEJ",
+                "type": "list",
+                "title": "Do you need to do any further feasibility work?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bBGnkL",
+            "question": "Feasiblity studies you've carried out"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "operational-costs-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qXNkfr",
+                "type": "freeText",
+                "title": "Summarise your income and operational costs for the running of the asset",
+                "answer": "\u003Cp\u003E\u003Cstrong\u003Etest\u003C/strong\u003E\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "oSfXFZ",
+            "question": "Forecasted income and operational costs to run the asset"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "community-representation-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ReomFo",
+                "type": "freeText",
+                "title": "List the members of your board",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "fjVmOt",
+                "type": "freeText",
+                "title": "Tell us about your governance and membership structures",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "GETNxN",
+                "type": "freeText",
+                "title": "Explain how you'll consider the views of the community in the running of the asset",
+                "answer": "\u003Col\u003E\r\n\u003Cli\u003Etest\u003C/li\u003E\r\n\u003C/ol\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "KbnmOO",
+            "question": "How you’ll run the asset"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "inclusiveness-and-integration-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "mgIesb",
+                "type": "freeText",
+                "title": "Tell us how the asset will be accountable to local people, and involve them in its running",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              },
+              {
+                "key": "lQEkep",
+                "type": "freeText",
+                "title": "Describe anything that might prevent people from using the asset or participating in its running",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eCZBSV",
+            "question": "How you’ll make the asset inclusive"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "skills-and-resources-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XXGyzn",
+                "type": "freeText",
+                "title": "Describe any relevant experience you have delivering similar projects or running an asset",
+                "answer": "\u003Cp\u003Etest\u003C/p\u003E"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eLpYFr",
+            "question": "Your experience running similar assets"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "Uaeyae",
+                "type": "list",
+                "title": "Do you have plans to recruit people to help you run the asset?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eLpYFr",
+            "question": "Recruitment plans"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      }
+    ],
+    "status": "SUBMITTED",
+    "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+    "language": "en",
+    "round_id": "33726b63-efce-4749-b149-20351346c76e",
+    "reference": "COF-R4W1-JFKXTU",
+    "account_id": "1e8884e2-b043-427f-ba09-7ec2ca409ef0",
+    "round_name": "Round 4 Window 4",
+    "started_at": "2024-01-04T15:48:57.567040",
+    "last_edited": "2024-01-04T15:54:15.234643",
+    "project_name": "Rebuild the vintage community centre in Cardiff",
+    "date_submitted": "2024-01-04T15:54:30.373564"
+  },
+  {
+    "id": "6ba41cf1-9152-4fd4-9e41-1348304ef655",
+    "forms": [
+      {
+        "name": "cynaliadwyedd-amgylcheddol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "dypuJs",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut rydych wedi ystyried cynaliadwyedd amgylcheddol eich prosiect",
+                "answer": "<p>asdfadsf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "ljcxPd",
+            "question": "Sut ydych chi wedi ystyried yr amgylchedd"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "dichonoldeb-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "iSbwDM",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am yr astudiaethau dichonoldeb rydych wedi'u cynnal ar gyfer eich prosiect",
+                "answer": "<p>asdfasdf</p>"
+              },
+              {
+                "key": "jFPlEJ",
+                "type": "list",
+                "title": "A oes angen i chi ymgymryd ag unrhyw waith pellach yn ymwneud \u00e2 dichonoldeb?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bBGnkL",
+            "question": "Astudiaethau dichonoldeb a gynhalioch"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "gwybodaeth-am-yr-ymgeisydd-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "SnLGJE",
+                "type": "text",
+                "title": "Enw'r cyswllt arweiniol",
+                "answer": "asdf"
+              },
+              {
+                "key": "qRDTUc",
+                "type": "text",
+                "title": "Teitl swydd cyswllt arweiniol",
+                "answer": "asdf"
+              },
+              {
+                "key": "NlHSBg",
+                "type": "text",
+                "title": "Cyfeiriad e-bost y cyswllt arweiniol",
+                "answer": "adsf@asdf.com"
+              },
+              {
+                "key": "FhBkJQ",
+                "type": "text",
+                "title": "Rhif ff\u00f4n y cyswllt arweiniol",
+                "answer": "0123123123"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "ZuHuGk",
+            "question": "Manylion y prif gyswllt"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "defnydd-cymunedol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "zTcrYo",
+                "type": "freeText",
+                "title": "Pwy yn y gymuned sy'n defnyddio'r ased ar hyn o bryd, neu sydd wedi'i ddefnyddio yn y gorffennol?",
+                "answer": "<ol>\r\n<li>adfasdf</li>\r\n</ol>"
+              },
+              {
+                "key": "whlRYS",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut byddai colli'r ased yn effeithio ar bobl yn y gymuned, neu sut mae wedi effeithio arnynt yn barod",
+                "answer": "<p>asdfadsf</p>"
+              },
+              {
+                "key": "NGSXHE",
+                "type": "freeText",
+                "title": "Pam bydd yr ased yn cael ei golli heb ymyrraeth gan y gymuned?",
+                "answer": "<p>adsfafds</p>"
+              },
+              {
+                "key": "Ieudgn",
+                "type": "freeText",
+                "title": "Eglurwch sut y bydd y gymuned yn cael ei gwasanaethu'n well gyda'r ased sydd o dan berchnogaeth gymunedol",
+                "answer": "<p>asdadsf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "GMkooI",
+            "question": "Pwy sy'n defnyddio'r ased"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "cefnogaeth-leol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "tDVPnl",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am y gefnogaeth leol i'ch prosiect",
+                "answer": "<p>asdfasdf</p>"
+              },
+              {
+                "key": "bDWjTN",
+                "type": "text",
+                "title": "Lanlwythwch dystiolaeth ategol (dewisol)",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "apkBSm",
+            "question": "Eich cefnogaeth ar gyfer y prosiect"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "risg-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "EODncR",
+                "type": "text",
+                "title": "Risgiau i'ch prosiect (lanlwytho dogfen)",
+                "answer": "output_tracker_2024-04-09_08-59-02_en.csv"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "HKdODf",
+            "question": "Cofrestr risg eich prosiect"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "lanlwythwch-y-cynllun-busnes-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ndpQJk",
+                "type": "text",
+                "title": "Lanlwythwch y cynllun busnes",
+                "answer": "output_tracker_2024-04-09_08-59-02_en.csv"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "xtwqlH",
+            "question": "Eich cynllun busnes"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "gwybodaeth-am-y-prosiect-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "pWwCRM",
+                "type": "list",
+                "title": "Ydych chi wedi gwneud cais i'r Gronfa Perchnogaeth Gymunedol o'r blaen?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Ceisiadau Cronfa Perchnogaeth Gymunedol blaenorol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "apGjFS",
+                "type": "text",
+                "title": "Enw'r prosiect",
+                "answer": "asdf"
+              },
+              {
+                "key": "bEWpAj",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut mae'r ased yn cael ei ddefnyddio ar hyn o bryd, neu sut mae wedi'i ddefnyddio'n flaenorol, a pham mae'n bwysig i'r gymuned",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "uypCNM",
+                "type": "freeText",
+                "title": "Rhowch grynodeb byr o'ch prosiect, gan gynnwys beth rydych chi'n gobeithio ei gyflawni",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "AgeRbd",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am y gweithgareddau a/neu'r gwasanaethau arfaethedig a fydd yn digwydd yn yr ased",
+                "answer": "<p>asdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Enw'r prosiect a chrynodeb ohono"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "EfdliG",
+                "type": "text",
+                "title": "Cyfeiriad yr ased cymunedol",
+                "answer": "line 1, null, town, null, PL11RN"
+              },
+              {
+                "key": "fIEUcb",
+                "type": "text",
+                "title": "Ym mha etholaeth mae eich ased?",
+                "answer": "asdf"
+              },
+              {
+                "key": "SWfcTo",
+                "type": "text",
+                "title": "Ym mha ardal cyngor lleol mae eich ased?",
+                "answer": "asdf"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "qsnIGd",
+            "question": "Cyfeiriad yr ased"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "buddion-cymunedol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "pqYxJO",
+                "type": "list",
+                "title": "Pa fuddion cymunedol ydych chi'n disgwyl eu cyflawni gyda'r prosiect hwn?",
+                "answer": [
+                  "Ymddiriedaeth gymdeithasol, cydlyniant ac ymdeimlad o berthyn"
+                ]
+              },
+              {
+                "key": "lgfiGB",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am y manteision hyn yn fanwl, a sut y bydd gweithgareddau'r ased yn helpu i'w cyflawni",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "zKKouR",
+                "type": "freeText",
+                "title": "Eglurwch sut rydych yn bwriadu cyflawni a chynnal y buddion hyn dros amser",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "ZyIQGI",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut byddwch chi'n gwneud yn si\u0175r bod y gymuned gyfan yn elwa o'r ased",
+                "answer": "<p>asdfa</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "PTOBPV",
+            "question": "Buddion y byddwch yn eu darparu"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "gwybodaeth-am-y-sefydliad-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "WWWWxy",
+                "type": "text",
+                "title": "Cyfeirnod eich ffurflen mynegi diddordeb (EOI).",
+                "answer": "asdf"
+              },
+              {
+                "key": "YdtlQZ",
+                "type": "text",
+                "title": "Enw'r sefydliad",
+                "answer": "asdf"
+              },
+              {
+                "key": "iBCGxY",
+                "type": "list",
+                "title": "A yw eich sefydliad yn defnyddio unrhyw enwau eraill?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Enwau'r sefydliad"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "emVGxS",
+                "type": "freeText",
+                "title": "Beth yw prif ddiben eich sefydliad?",
+                "answer": "<p>asdfasdf</p>"
+              },
+              {
+                "key": "btTtIb",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad",
+                "answer": "<p>adsfadfs</p>"
+              },
+              {
+                "key": "SkocDi",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad - Gweithgarwch 2 ",
+                "answer": "<p>asdfadsf</p>"
+              },
+              {
+                "key": "CNeeiC",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad - Gweithgarwch 3 ",
+                "answer": null
+              },
+              {
+                "key": "BBlCko",
+                "type": "list",
+                "title": "A ydych chi wedi cyflawni prosiectau fel hwn o'r blaen?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Diben a gweithgareddau"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "lajFtB",
+                "type": "list",
+                "title": "Math o sefydliad",
+                "answer": "Cwmni cydweithredol, fel cymdeithas budd cymunedol"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Sut mae eich sefydliad yn cael ei ddosbarthu"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "GlPmCX",
+                "type": "text",
+                "title": "Rhif cofrestru'r cwmni",
+                "answer": "asdf"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Manylion cofrestru'r cwmni"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "GvPSna",
+                "type": "list",
+                "title": "Gyda pha gorff rheoleiddio y mae eich cwmni wedi'i gofrestru?",
+                "answer": "Arall"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Manylion cofrestru"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "zsbmRx",
+                "type": "text",
+                "title": "Gyda pha gorff rheoleiddio y mae eich cwmni wedi'i gofrestru? (Arall)",
+                "answer": "asdfadsf"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Yngl\u0177n \u00e2'ch sefydliad"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "DwfHtk",
+                "type": "list",
+                "title": "A yw eich sefydliad yn is-gwmni masnachol i riant-gwmni?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Is-gwmn\u00efau masnachu"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ZQolYb",
+                "type": "text",
+                "title": "Cyfeiriad y sefydliad",
+                "answer": "line 1, null, town, county, PL11RN"
+              },
+              {
+                "key": "zsoLdf",
+                "type": "list",
+                "title": "A yw eich cyfeiriad gohebu yn wahanol i gyfeiriad y sefydliad?",
+                "answer": false
+              },
+              {
+                "key": "FhbaEy",
+                "type": "text",
+                "title": "Gwefan a chyfryngau cymdeithasol",
+                "answer": "https://asdfasdf.com"
+              },
+              {
+                "key": "FcdKlB",
+                "type": "text",
+                "title": "Gwefan a chyfryngau cymdeithasol - Dolen 2",
+                "answer": null
+              },
+              {
+                "key": "BzxgDA",
+                "type": "text",
+                "title": "Gwefan a chyfryngau cymdeithasol - Dolen 3",
+                "answer": null
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Cyfeiriad y sefydliad"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "hnLurH",
+                "type": "list",
+                "title": "A yw eich cais yn gynnig ar y cyd mewn partneriaeth \u00e2 sefydliadau eraill",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "JBqDtK",
+            "question": "Ceisiadau ar y cyd"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "ymgysylltiad-cymunedol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "azCutK",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut rydych wedi ymgysylltu \u00e2'r gymuned yngl\u0177n \u00e2'ch bwriad i gymryd perchnogaeth o'r ased",
+                "answer": "<p>asdfadsf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "Sut ydych chi wedi ymgysylltu \u00e2'r gymuned"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "jAhuWN",
+                "type": "freeText",
+                "title": "Disgrifiwch eich gweithgareddau codi arian",
+                "answer": "<p>asdfasdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "Eich gweithgareddau codi arian"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "HYsezC",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am unrhyw bartneriaethau rydych wedi'u ffurfio, a sut y byddant yn helpu'r prosiect i fod yn llwyddiannus",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "GGBgBY",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut mae eich prosiect yn cefnogi unrhyw gynlluniau lleol ehangach",
+                "answer": "<p>asdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "lmdhVN",
+            "question": "Partneriaethau a chynlluniau lleol"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "gwybodaeth-am-yr-ased-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "oXGwlA",
+                "type": "list",
+                "title": "Math o ased",
+                "answer": "Arall"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Sut mae'r eiddo'n cael ei ddefnyddio yn y gymuned"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "aJGyCR",
+                "type": "text",
+                "title": "Math o eiddo (arall)",
+                "answer": "other asset type"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Sut mae'r eiddo'n cael ei ddefnyddio yn y gymuned"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "LaxeJN",
+                "type": "list",
+                "title": "Sut ydych yn bwriadu meddu'r eiddo ar y gymuned?",
+                "answer": "Eisoes wedi'i llogi gan eich sefydliad"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Yr eiddo mewn meddiannu cymunedol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "tTOrEp",
+                "type": "text",
+                "title": "Lanlwythwch dystiolaeth i gadarnhau'r wybodaeth uchod a bod yr eiddo mewn perygl",
+                "answer": "output_tracker_2024-04-09_08-59-02_cy.csv"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Lanlwytho gwerthiant ar\u00e2d eiddo neu gytundeb i fenthyg"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "wAUFqr",
+                "type": "list",
+                "title": "A ydych yn gwybod pwy sy'n meddu ar eich eiddo ar hyn o bryd?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Pwy sy'n meddu ar yr eiddo"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XiHjDO",
+                "type": "text",
+                "title": "Dywedwch wrthym beth rydych yn ei wybod am werthiant neu lyniant yr eiddo",
+                "answer": "dsfsdaffads"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Statws presennol y meddiant"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XPcbJx",
+                "type": "freeText",
+                "title": "Disgrifiwch y broses werthu ddisgrifiwch, neu'r telerau arfaethedig o'ch denantiaeth os ydych yn bwriadu rhentu'r eiddo",
+                "answer": "<p>asdfadsf</p>"
+              },
+              {
+                "key": "jGjScT",
+                "type": "date",
+                "title": "Dyddiad disgwyliedig y gwerthiant neu'r trosglwyddiad",
+                "answer": "2023-01-01"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Amodau arthrog ddenant profiadwy"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "VGXXyq",
+                "type": "list",
+                "title": "A yw eich eiddo'n cael ei berchen gan y cyhoedd ar hyn o bryd?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Perchenogaeth gyhoeddus"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qlqyUq",
+                "type": "list",
+                "title": "Pam mae'r eiddo mewn perygl cau?",
+                "answer": [
+                  "Cau"
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Perygl cau"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "iqnlTk",
+                "type": "list",
+                "title": "Ai hwn yw Ased Gymunedol Cofrestredig (ACV)?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Asedau o werth cymunedol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "mZwrmI",
+                "type": "list",
+                "title": "Oes mathau tebyg o asedau neu wasanaethau ar gael yn lleol?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Darparu gwasanaeth lleol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "GEJNWF",
+                "type": "freeText",
+                "title": "Pa mor hygyrch yw'r ased neu'r gwasanaeth agosaf?",
+                "answer": "<p>adsfafds</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Darparu gwasanaeth lleol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "CFFsxV",
+                "type": "list",
+                "title": "A yw rhan o'ch prosiect yn cynnwys agwedd fasnachol?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "wxYZcT",
+            "question": "Darparu gwasanaeth lleol"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "cadarnhadau-terfynol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "vSQKwD",
+                "type": "list",
+                "title": "Cadarnhewch eich bod wedi ystyried goblygiadau rheoli cymhorthdal a chymorth gwladwriaethol ar gyfer eich prosiect, a bod y wybodaeth rydych wedi'i rhoi i ni yn gywir",
+                "answer": true
+              },
+              {
+                "key": "CQoLFp",
+                "type": "list",
+                "title": "Cadarnhewch eich bod wedi ystyried pobl \u00e2 nodweddion gwarchodedig drwy gydol proses cynllunio'ch prosiect",
+                "answer": true
+              },
+              {
+                "key": "jdPkiX",
+                "type": "list",
+                "title": "Cadarnhewch eich bod wedi ystyried cynaliadwyedd a'r amgylchedd drwy gydol proses cynllunio'ch prosiect, gan gynnwys cydymffurfio ag uchelgeisiau Sero Net y llywodraeth",
+                "answer": true
+              },
+              {
+                "key": "qWuSCy",
+                "type": "list",
+                "title": "Cadarnhewch eich bod wedi sefydlu cyfrif banc ac yn gysylltiedig \u00e2'r sefydliad yr ydych chi'n gwneud cais ar ei ran",
+                "answer": true
+              },
+              {
+                "key": "tjZlml",
+                "type": "list",
+                "title": "Cadarnhewch fod y wybodaeth a ddarparwyd gennych yn y cais hwn yn gywir hyd eithaf eich gwybodaeth ar y dyddiad cyflwyno",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "LkvizC",
+            "question": "Cytuno i'r cadarnhad terfynol"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "cyllid-sydd-ei-angen-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ABROnB",
+                "type": "text",
+                "title": "Cais cyllido cyfalaf",
+                "answer": "234234"
+              },
+              {
+                "key": "hJkmBS",
+                "type": "list",
+                "title": "Os ydych yn llwyddiannus, a wnewch chi ddefnyddio eich cyllid o fewn y 12 mis nesaf?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Cais cyllido cyfalaf"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qQLyXL",
+                "type": "multiInput",
+                "title": "Costau cyfalaf",
+                "answer": [
+                  {
+                    "GLQlOh": "asdfasdf",
+                    "JtwkMy": 234234,
+                    "LeTLDo": 234,
+                    "pHZDWT": 234
+                  }
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Costau cyfalaf ar gyfer eich prosiect"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "DOvZvB",
+                "type": "list",
+                "title": "A ydych wedi sicrhau unrhyw gyllid cydweddu eto?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Os byddwch wedi sicrhau cyllid cydweddu"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "MopCmv",
+                "type": "multiInput",
+                "title": "Cyllid cydweddu wedi'i sicrhau",
+                "answer": [
+                  {
+                    "JKqLWU": "asdf",
+                    "LVJcDC": 234
+                  },
+                  {
+                    "JKqLWU": "asdf",
+                    "LVJcDC": 234
+                  }
+                ]
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Cyllid cydweddu wedi'i sicrhau"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "HgpNUe",
+                "type": "list",
+                "title": "A ydych di ddylu bydd chi wedi defnyddio yr cyllid cydweddu y chydwybododd chi?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "A ydych di ddylu bydd chi wedi defnyddio yr cyllid cydweddu y chydwybododd chi?"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "DmgsiG",
+                "type": "list",
+                "title": "A ydych wedi nodi, ond heb ei sicrhau eto, unrhyw gyllid cydweddu ychwanegol?",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Os byddwch wedi nodi, ond heb ei sicrhau eto, unrhyw gyllid cydweddu ychwanegol"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "matkNH",
+                "type": "list",
+                "title": "A ydych yn gwneud cais am gyllid refeniw o Gronfa Perchen Cymunedol? (dewisol)",
+                "answer": false
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "bgUGuD",
+            "question": "Cyllid refeniw"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "costau-gweithredol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "qXNkfr",
+                "type": "freeText",
+                "title": "Crynodeb o'ch incwm a'ch costau gweithredol i redeg yr ased",
+                "answer": "<p>asdfasdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "oSfXFZ",
+            "question": "Incwm rhagweladwy a chostau gweithredol i redeg yr ased"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "sgiliau-ac-adnoddau-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "XXGyzn",
+                "type": "freeText",
+                "title": "Disgrifiwch unrhyw brofiad perthnasol sydd gennych o gyflawni prosiectau tebyg neu redeg ased",
+                "answer": "<p>asdfadsf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eLpYFr",
+            "question": "Eich profiad o redeg asedau tebyg"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "Uaeyae",
+                "type": "list",
+                "title": "A oes gennych gynlluniau i recriwtio pobl i'ch helpu i redeg yr ased?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eLpYFr",
+            "question": "Cynlluniau recriwtio"
+          },
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "yHXVSA",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am y rolau y byddwch yn eu recriwtio",
+                "answer": "<p>asdfadsf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eLpYFr",
+            "question": "Rolau y byddwch yn recriwtio iddynt i'ch helpu i redeg yr ased"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "cynrychiolaeth-gymunedol-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "ReomFo",
+                "type": "freeText",
+                "title": "Rhestrwch aelodau eich bwrdd",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "fjVmOt",
+                "type": "freeText",
+                "title": "Dywedwch wrthym am eich strwythurau llywodraethu ac aelodaeth",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "GETNxN",
+                "type": "freeText",
+                "title": "Eglurwch sut byddwch chi'n ystyried barn y gymuned wrth redeg yr ased",
+                "answer": "<p>asdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "KbnmOO",
+            "question": "Sut byddwch chi'n rhedeg yr ased"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      },
+      {
+        "name": "cynhwysiant-ac-integreiddio-cof",
+        "status": "COMPLETED",
+        "questions": [
+          {
+            "index": 0,
+            "fields": [
+              {
+                "key": "mgIesb",
+                "type": "freeText",
+                "title": "Dywedwch wrthym sut y bydd yr ased yn atebol i bobl leol, a'u cynnwys yn y gwaith o'i redeg",
+                "answer": "<p>asdf</p>"
+              },
+              {
+                "key": "lQEkep",
+                "type": "freeText",
+                "title": "Disgrifiwch unrhyw beth a allai atal pobl rhag defnyddio'r ased neu gyfranogi yn y gwaith o redeg yr ased",
+                "answer": "<p>asdf</p>"
+              }
+            ],
+            "status": "COMPLETED",
+            "category": "eCZBSV",
+            "question": "Sut byddwch chi'n gwneud yr ased yn gynhwysol"
+          },
+          {
+            "fields": [
+              {
+                "key": "markAsComplete",
+                "type": "boolean",
+                "title": "Do you want to mark this section as complete?",
+                "answer": true
+              }
+            ],
+            "status": "COMPLETED",
+            "category": null,
+            "question": "MarkAsComplete"
+          }
+        ]
+      }
+    ],
+    "status": "SUBMITTED",
+    "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+    "language": "cy",
+    "round_id": "33726b63-efce-4749-b149-20351346c76e",
+    "reference": "COF-R4W1-BMXPDO",
+    "account_id": "4d6f9703-41c9-4de1-a41e-e758d30251c3",
+    "round_name": "Round 4 Window 1",
+    "started_at": "2024-04-10T07:26:45.231275",
+    "last_edited": "2024-04-10T07:41:15.676601",
+    "project_name": "asdf",
+    "date_submitted": "2024-04-10T07:41:36.979794"
   }
 ]

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -406,9 +406,11 @@ def test_output_tracker_with_no_scores_data(seed_application_records, mocker):
 
 @pytest.mark.apps_to_insert([test_input_data[4]])  # taken from assessment store for cof r4w1
 def test_get_cof_r4w1_export_data_en(seed_application_records):
-    test_record = get_assessment_record(test_input_data[4]["id"])
+    app_id = test_input_data[4]["id"]
+    test_record = get_assessment_record(app_id)
     result = get_export_data("round_id", "ASSESSOR_EXPORT", applicant_info_mapping[COF_FUND_ID], [test_record], "en")
     assert len(result) == 1
+    assert str(result[0]["Application ID"]) == app_id
     assert result[0]["Name of lead contact"] == "test lead person"
     assert result[0]["Type of organisation"] == "CIO"
     assert result[0]["Asset type"] == "community-centre"
@@ -416,13 +418,17 @@ def test_get_cof_r4w1_export_data_en(seed_application_records):
     assert result[0]["Charity number"] == "786786"
     assert result[0]["Organisation address"] == "test, test, test, test, ss12ss"
     assert result[0]["Postcode of asset"] == "NP10 8QQ"
+    assert result[0]["Capital funding request"] == "966585"
+    assert result[0]["Revenue costs (optional)"] == 456
 
 
 @pytest.mark.apps_to_insert([test_input_data[5]])  # taken from assessment store for cof r4w1
 def test_get_cof_r4w1_export_data_cy(seed_application_records):
-    test_record = get_assessment_record(test_input_data[5]["id"])
+    app_id = test_input_data[5]["id"]
+    test_record = get_assessment_record(app_id)
     result = get_export_data("round_id", "ASSESSOR_EXPORT", applicant_info_mapping[COF_FUND_ID], [test_record], "cy")
     assert len(result) == 1
+    assert str(result[0]["Application ID"]) == app_id
     assert result[0]["Enw'r cyswllt arweiniol"] == "asdf"
     assert result[0]["Math o sefydliad"] == "Cwmni cydweithredol, fel cymdeithas budd cymunedol"
     assert result[0]["Math o ased"] == "Arall"
@@ -430,3 +436,5 @@ def test_get_cof_r4w1_export_data_cy(seed_application_records):
     assert result[0]["Rhif elusen"] == ""
     assert result[0]["Cyfeiriad y sefydliad"] == "line 1, town, county, PL11RN"
     assert result[0]["Cod post o ased"] == "PL11RN"
+    assert result[0]["Cais cyllido cyfalaf"] == "234234"
+    assert result[0]["Costau refeniw (dewisol)"] == ""

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -2,6 +2,8 @@ import random
 
 import pytest
 import sqlalchemy
+from config.mappings.assessment_mapping_fund_round import applicant_info_mapping
+from config.mappings.assessment_mapping_fund_round import COF_FUND_ID
 from db.models import Comment
 from db.models import Score
 from db.models.assessment_record.assessment_records import AssessmentRecord
@@ -14,6 +16,7 @@ from db.queries.assessment_records.queries import (
 )
 from db.queries.assessment_records.queries import find_assessor_task_list_state
 from db.queries.assessment_records.queries import get_assessment_export_data
+from db.queries.assessment_records.queries import get_export_data
 from db.queries.comments.queries import create_comment_for_application_sub_crit
 from db.queries.comments.queries import get_comments_for_application_sub_crit
 from db.queries.comments.queries import get_sub_criteria_to_has_comment_map
@@ -399,3 +402,31 @@ def test_output_tracker_with_no_scores_data(seed_application_records, mocker):
     assert data["en_list"][0]["Do you need to do any further feasibility work?"] is False
     assert data["en_list"][0]["Project name"] == "Save the humble pub in Bangor"
     assert data["en_list"][0]["Risks to your project (document upload)"] == "sample1.doc"
+
+
+@pytest.mark.apps_to_insert([test_input_data[4]])  # taken from assessment store for cof r4w1
+def test_get_cof_r4w1_export_data_en(seed_application_records):
+    test_record = get_assessment_record(test_input_data[4]["id"])
+    result = get_export_data("round_id", "ASSESSOR_EXPORT", applicant_info_mapping[COF_FUND_ID], [test_record], "en")
+    assert len(result) == 1
+    assert result[0]["Name of lead contact"] == "test lead person"
+    assert result[0]["Type of organisation"] == "CIO"
+    assert result[0]["Asset type"] == "community-centre"
+    assert result[0]["Type of asset (other)"] == ""
+    assert result[0]["Charity number"] == "786786"
+    assert result[0]["Organisation address"] == "test, test, test, test, ss12ss"
+    assert result[0]["Postcode of asset"] == "NP10 8QQ"
+
+
+@pytest.mark.apps_to_insert([test_input_data[5]])  # taken from assessment store for cof r4w1
+def test_get_cof_r4w1_export_data_cy(seed_application_records):
+    test_record = get_assessment_record(test_input_data[5]["id"])
+    result = get_export_data("round_id", "ASSESSOR_EXPORT", applicant_info_mapping[COF_FUND_ID], [test_record], "cy")
+    assert len(result) == 1
+    assert result[0]["Enw'r cyswllt arweiniol"] == "asdf"
+    assert result[0]["Math o sefydliad"] == "Cwmni cydweithredol, fel cymdeithas budd cymunedol"
+    assert result[0]["Math o ased"] == "Arall"
+    assert result[0]["Math o eiddo (arall)"] == "other asset type"
+    assert result[0]["Rhif elusen"] == ""
+    assert result[0]["Cyfeiriad y sefydliad"] == "line 1, town, county, PL11RN"
+    assert result[0]["Cod post o ased"] == "PL11RN"


### PR DESCRIPTION
### Change description
For COF R4W1 they want additional fields in the applicant info export (see ticket for the list). This PR:
- Adds those fields
- Adds unit tests for those fields
- Updates the `get_export_data` function to allow for new field types (postcode, sum of values)
- Updates the seed data script to work properly

---

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Navigate to assessment
- Click 'Export Applicant Information' for COF R4W1
- View the CSV and check all fields hold correct values

