### PR TITLE
BAU Renaming scoring enum and setting is_withdrawn nullable=false

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,7 +63,7 @@
     "args": [
       "db",
       "downgrade",
-      "ea9b2ccebd34" // modify the downgrade revision accordingly
+      "6c8205510de6" // modify the downgrade revision accordingly
     ]
   },
   {

--- a/db/migrations/versions/~2024_04_16_1018-dac03038236f_.py
+++ b/db/migrations/versions/~2024_04_16_1018-dac03038236f_.py
@@ -1,0 +1,38 @@
+"""Setting is_withdrawn to nullable=True, and renaming scoring system enum.
+
+Revision ID: dac03038236f
+Revises: 6c8205510de6
+Create Date: 2024-04-16 10:18:08.511694
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dac03038236f"
+down_revision = "6c8205510de6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.alter_column("is_withdrawn", existing_type=sa.BOOLEAN(), nullable=False)
+
+    op.execute("CREATE TYPE scoringsystem AS ENUM ('OneToFive', 'ZeroToThree')")
+    op.execute(
+        "ALTER TABLE assessment_round ALTER COLUMN scoring_system TYPE scoringsystem"
+        " USING scoring_system::text::scoringsystem"
+    )
+    op.execute("DROP TYPE scoring_system_enum")
+
+
+def downgrade():
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.alter_column("is_withdrawn", existing_type=sa.BOOLEAN(), nullable=True)
+    op.execute("CREATE TYPE scoring_system_enum AS ENUM ('OneToFive', 'ZeroToThree')")
+    op.execute(
+        "ALTER TABLE assessment_round ALTER COLUMN scoring_system TYPE scoring_system_enum "
+        "USING scoring_system::text::scoring_system_enum"
+    )
+    op.execute("DROP TYPE scoringsystem")

--- a/db/models/score/enums.py
+++ b/db/models/score/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class ScoringSysyem(Enum):
+class ScoringSystem(Enum):
     """The ENUM used by `db.models.AssessmentRound` to validate the possible
     values for the `scoring_system` column."""
 

--- a/db/models/score/scores.py
+++ b/db/models/score/scores.py
@@ -3,7 +3,7 @@ Postgres db."""
 import uuid
 
 from db import db
-from db.models.score.enums import ScoringSysyem
+from db.models.score.enums import ScoringSystem
 from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.dialects.postgresql import UUID
@@ -39,4 +39,4 @@ class AssessmentRound(db.Model):
 
     round_id = db.Column("round_id", UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
 
-    scoring_system = db.Column("scoring_system", ENUM(ScoringSysyem), nullable=False)
+    scoring_system = db.Column("scoring_system", ENUM(ScoringSystem), nullable=False)


### PR DESCRIPTION
### Change description
Discovered that the migrations files aren't up to date with the model files. This PR creates a new migration that matches the model files. Changes are:
- setting assessment_record.is_withdrawn to `is_nullable=True`
- changing the name of the scoring system enum from `scoring_system_enum` to `scoring_system`

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Run DB upgrade to revision `dac03038236f`
- Run DB downgrade to revision `6c8205510de6`

