### PR TITLE
FS:4389 HSRA Assessment file path bug fix

### DIFF
--- a/config/mappings/hsra_mapping_parts/r1_scored_criteria.py
+++ b/config/mappings/hsra_mapping_parts/r1_scored_criteria.py
@@ -75,6 +75,7 @@ scored_criteria = [
                                 "field_type": "clientSideFileUploadField",
                                 "presentation_type": "s3bucketPath",
                                 "question": "Upload quotes showing refurbishment costs and if applicable project management costs for properties exceeding 200 sqm.",
+                                "path": "upload-quotes-showing-refurbishment-costs-and-if-applicable-project-management-costs-for-properties-exceeding-200-sqm.",
                             },
                             {
                                 "field_id": "SMwXcK",
@@ -82,6 +83,7 @@ scored_criteria = [
                                 "field_type": "clientSideFileUploadField",
                                 "presentation_type": "s3bucketPath",
                                 "question": "Upload the independent survey of works",
+                                "path": "upload-the-independent-survey-of-works",
                             },
                         ],
                     }
@@ -108,6 +110,7 @@ scored_criteria = [
                                 "field_type": "clientSideFileUploadField",
                                 "presentation_type": "s3bucketPath",
                                 "question": "Upload quotes showing other costs",
+                                "path": "upload-quotes-showing-other-costs",
                             },
                         ],
                     }
@@ -141,6 +144,7 @@ scored_criteria = [
                                 "field_type": "clientSideFileUploadField",
                                 "presentation_type": "s3bucketPath",
                                 "question": "Upload the initial notice you served the landlord",
+                                "path": "upload-the-initial-notice-you-served-the-landlord",
                             },
                             {
                                 "field_id": "NnOqGc",

--- a/config/mappings/hsra_mapping_parts/r1_unscored_sections.py
+++ b/config/mappings/hsra_mapping_parts/r1_unscored_sections.py
@@ -147,4 +147,29 @@ unscored_sections = [
             },
         ],
     },
+    {
+        "id": "declaration",
+        "name": "Declaration",
+        "sub_criteria": [
+            {
+                "id": "declaration",
+                "name": "Declaration",
+                "themes": [
+                    {
+                        "id": "declaration",
+                        "name": "Declaration",
+                        "answers": [
+                            {
+                                "field_id": "QUaOGq",
+                                "form_name": "declaration-hsra",
+                                "field_type": "checkboxesField",
+                                "presentation_type": "list",
+                                "question": "By submitting this application, you confirm that the information you have provided is correct.",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
 ]


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-4389


## Change description
- Bug fixture for HSRA uploaded file on assessment
- Declaration section added for HSRA assessment configs in assessment

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


## Screenshots of UI changes (if applicable)

### Declaration section added:

<img width="986" alt="Screenshot 2024-06-07 at 16 38 15" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/66220499/532ddfc6-797c-4d81-82e3-101fadbaecab">

### Refurbishment costs and other sections are now accessible:

<img width="1380" alt="Screenshot 2024-06-07 at 16 41 24" src="https://github.com/communitiesuk/funding-service-design-assessment-store/assets/66220499/e460f337-5aab-4803-b155-c90df453ea41">
