### PR TITLE
BAU Dont override user workspace colour preferences

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,4 @@
 {
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#10a84a",
-    "titleBar.activeBackground": "#10a84a",
-    "titleBar.activeForeground": "#ffffff"
-  },
-  "editor.formatOnSave": false,
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
### Change description
Remove the colour customisations specified at the repository configuration level.

Developers can still specify their own customisations for the workspaces.

The current version of vscode has very little contrast with the chosen colour scheme which makes it hard to use.

This also removes an override for formatting on saving which can also now be chosen by the developer based on their setup -- formatting issues should be caught in pre-commit checks both locally and during the CI process.

Example of low contrast icons with the repository specified colour scheme
<img width="44" alt="Grey icons on a bright green background - an example of low contrast icons with the repository specified colour scheme" src="https://github.com/user-attachments/assets/502b2ae3-c3f1-417c-84cf-4a04f27861ac">


- ~[ ] Unit tests and other appropriate tests added or updated~
- ~[ ] README and other documentation has been updated / added (if needed)~
- [x] Commit messages are meaningful and follow good commit message guidelines