### PR TITLE
FS-4446: Consistent CSV File Columns

### DIFF
--- a/config/mappings/assessment_mapping_fund_round.py
+++ b/config/mappings/assessment_mapping_fund_round.py
@@ -261,8 +261,8 @@ applicant_info_mapping = {
             "score_fields": {
                 "Application ID",
                 "Short ID",
-                "Score Subcriteria",
                 "Score",
+                "Score Subcriteria",
                 "Score Date",
                 "Score Time",
             },

--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -576,8 +576,8 @@ def get_assessment_records_score_data_by_round_id(round_id, selected_fields=None
     default_fields = [
         "Application ID",
         "Short ID",
-        "Score Subcriteria",
         "Score",
+        "Score Subcriteria",
         "Score Justification",
         "Score Date",
         "Score Time",

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -553,10 +553,10 @@ def test_output_tracker_columns_remain_same_for_scored_and_unscored_reports(seed
             }
         },
     )
-  
-    no_scores_cols = list(no_scores['en_list'][0].keys())
-    with_scores_cols = list(with_scores['en_list'][0].keys())[:len(no_scores_cols)]
-    assert  no_scores_cols == with_scores_cols
+
+    no_scores_cols = list(no_scores["en_list"][0].keys())
+    with_scores_cols = list(with_scores["en_list"][0].keys())[: len(no_scores_cols)]
+    assert no_scores_cols == with_scores_cols
 
 
 @pytest.mark.apps_to_insert([test_input_data[4]])  # taken from assessment store for cof r4w1

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -507,6 +507,58 @@ def test_output_tracker_with_no_scores_data(seed_application_records, mocker):
     assert data["en_list"][0]["Risks to your project (document upload)"] == "sample1.doc"
 
 
+@pytest.mark.apps_to_insert([test_input_data[0]])
+def test_output_tracker_columns_remain_same_for_scored_and_unscored_reports(seed_application_records, mocker):
+    mocker.patch(
+        "db.queries.assessment_records.queries.get_account_name",
+        return_value="Test user",
+    )
+
+    picked_row = get_assessment_record(seed_application_records[0]["application_id"])
+
+    no_scores = get_assessment_export_data(
+        picked_row.fund_id,
+        picked_row.round_id,
+        "OUTPUT_TRACKER",
+        {
+            "OUTPUT_TRACKER": {
+                "form_fields": {
+                    "KAgrBz": {"en": {"title": "Project name"}},
+                }
+            }
+        },
+    )
+
+    application_id = picked_row.application_id
+    sub_criteria_id = "app-info"
+
+    assessment_payload = {
+        "application_id": application_id,
+        "sub_criteria_id": sub_criteria_id,
+        "score": 5,
+        "justification": "great",
+        "user_id": "test",
+    }
+    create_score_for_app_sub_crit(**assessment_payload)
+
+    with_scores = get_assessment_export_data(
+        picked_row.fund_id,
+        picked_row.round_id,
+        "OUTPUT_TRACKER",
+        {
+            "OUTPUT_TRACKER": {
+                "form_fields": {
+                    "KAgrBz": {"en": {"title": "Project name"}},
+                }
+            }
+        },
+    )
+  
+    with_scores_cols = list(with_scores['en_list'][0].keys())[:-5]
+    no_scores_cols = list(no_scores['en_list'][0].keys())
+    assert  with_scores_cols == no_scores_cols
+
+
 @pytest.mark.apps_to_insert([test_input_data[4]])  # taken from assessment store for cof r4w1
 def test_get_cof_r4w1_export_data_en(seed_application_records):
     app_id = test_input_data[4]["id"]

--- a/tests/test_db_function.py
+++ b/tests/test_db_function.py
@@ -554,9 +554,9 @@ def test_output_tracker_columns_remain_same_for_scored_and_unscored_reports(seed
         },
     )
   
-    with_scores_cols = list(with_scores['en_list'][0].keys())[:-5]
     no_scores_cols = list(no_scores['en_list'][0].keys())
-    assert  with_scores_cols == no_scores_cols
+    with_scores_cols = list(with_scores['en_list'][0].keys())[:len(no_scores_cols)]
+    assert  no_scores_cols == with_scores_cols
 
 
 @pytest.mark.apps_to_insert([test_input_data[4]])  # taken from assessment store for cof r4w1


### PR DESCRIPTION
[FS-446](https://dluhcdigital.atlassian.net/browse/FS-4446)


### Change description
Rearranged the default order of the columns so that Score comes directly after Date submitted regardless whether there is a score entered or not. Previously Score and Score Subcriteria could be swapped depending on if the first row had been scored yet)

- [x] Unit tests and other appropriate tests added or updated
- [ ] ~~README and other documentation has been updated / added (if needed)~~
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Open OUTPUT_TRACKER report for a window that has applications but no scores. Open OUTPUT_TRACKER for a window that has applications and are all scored. The columns should be in the same order for both reports.


### Screenshots of UI changes (if applicable)

Before fix (COF OUTPUT_TRACKER report):
![image](https://github.com/user-attachments/assets/504103f4-1667-4753-a0bb-75c0a1366564)
![image](https://github.com/user-attachments/assets/65489254-07be-40eb-8a53-654b9903649e)

NSTF OUTPUT_TRACKER report:
![image](https://github.com/user-attachments/assets/0a3879d1-0641-4de4-ae76-13ab38b28d04)
![image](https://github.com/user-attachments/assets/6c3e0387-a123-4838-984a-dd0c49114c90)

[FS-446]: https://dluhcdigital.atlassian.net/browse/FS-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


