### PR TITLE
Store assigner in allocation association log

### DIFF
--- a/db/queries/assessment_records/queries.py
+++ b/db/queries/assessment_records/queries.py
@@ -1003,7 +1003,7 @@ def create_user_application_association(application_id, user_id, assigner_id):
         application_id=application_id,
         assigner_id=assigner_id,
         active=True,
-        log={datetime.now(tz=timezone.utc).isoformat(): "activated"},
+        log={datetime.now(tz=timezone.utc).isoformat(): {"status": "activated", "assigner": str(assigner_id)}},
     )
     try:
         db.session.add(allocation_association)
@@ -1026,7 +1026,10 @@ def update_user_application_association(application_id, user_id, active, assigne
     allocation_association.active = active
     allocation_association.log = {
         **allocation_association.log,
-        datetime.now(tz=timezone.utc).isoformat(): "activated" if active else "deactivated",
+        datetime.now(tz=timezone.utc).isoformat(): {
+            "status": "activated" if active else "deactivated",
+            "assigner": str(assigner_id),
+        },
     }
     db.session.commit()
     db.session.refresh(allocation_association)

--- a/tests/test_db_allocation_associations.py
+++ b/tests/test_db_allocation_associations.py
@@ -21,14 +21,14 @@ def test_get_users_for_application(_db, seed_application_records):
         assigner_id=assigner_id,
         application_id=app_id,
         active=True,
-        log={datetime.now(tz=timezone.utc).isoformat(): "activated"},
+        log={datetime.now(tz=timezone.utc).isoformat(): {"status": "activated", "assigner": str(assigner_id)}},
     )
     allocation_association_2 = AllocationAssociation(
         user_id=user_id_2,
         assigner_id=assigner_id,
         application_id=app_id,
         active=False,
-        log={datetime.now(tz=timezone.utc).isoformat(): "deactivated"},
+        log={datetime.now(tz=timezone.utc).isoformat(): {"status": "deactivated", "assigner": str(assigner_id)}},
     )
     _db.session.add(allocation_association_1)
     _db.session.commit()
@@ -58,14 +58,14 @@ def test_get_applications_for_user(_db, seed_application_records):
         assigner_id=assigner_id_1,
         application_id=app_id_1,
         active=True,
-        log={datetime.now(tz=timezone.utc).isoformat(): "activated"},
+        log={datetime.now(tz=timezone.utc).isoformat(): {"status": "activated", "assigner": str(assigner_id_1)}},
     )
     allocation_association_2 = AllocationAssociation(
         user_id=user_id,
         assigner_id=assigner_id_2,
         application_id=app_id_2,
         active=False,
-        log={datetime.now(tz=timezone.utc).isoformat(): "deactivated"},
+        log={datetime.now(tz=timezone.utc).isoformat(): {"status": "deactivated", "assigner": str(assigner_id_2)}},
     )
     _db.session.add(allocation_association_1)
     _db.session.commit()
@@ -97,7 +97,7 @@ def test_create_user_application_association(_db, seed_application_records):
     assert str(new_association.application_id) == app_id
     assert str(new_association.user_id) == user_id
     assert new_association.active is True
-    assert "activated" == list(new_association.log.values())[0]
+    assert {"assigner": assigner_id, "status": "activated"} == list(new_association.log.values())[0]
     try:
         datetime.fromisoformat(list(new_association.log.keys())[0])
     except ValueError:
@@ -118,8 +118,8 @@ def test_update_user_application_association(_db, seed_application_records):
     logs = [(datetime.fromisoformat(key), value) for key, value in updated_association.log.items()]
 
     # The timestamp for deactivated should be after activated
-    assert logs[0][1] == "activated" if logs[0][0] < logs[1][0] else "deactivated"
-    assert logs[1][1] == "deactivated" if logs[0][0] < logs[1][0] else "activated"
+    assert logs[0][1]["status"] == "activated" if logs[0][0] < logs[1][0] else "deactivated"
+    assert logs[1][1]["status"] == "deactivated" if logs[0][0] < logs[1][0] else "activated"
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])


### PR DESCRIPTION
### Change description
Each allocation association (work assignment) contains a log to record history. This PR adds the assigner id for each action in the log. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
