### PR TITLE
Upgrade pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,10 @@ repos:
       name: Reorder Python imports (src, tests)
       args: ["--application-directories", "src"]
 - repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.5
+  # We are pinning a specific hash here because the current latest released version (v1.7.5) is
+  # incompatible with pre-commit v4+
+  # issue: https://github.com/PyCQA/docformatter/issues/289
+  rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
   hooks:
     - id: docformatter
       additional_dependencies: [tomli]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@ black
 deepdiff
 invoke
 pip-tools>=6.13.0
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -319,7 +319,7 @@ ply==3.11
     #   jsonpath-rw
 prance==23.6.21.0
     # via -r requirements.txt
-pre-commit==3.7.1
+pre-commit==4.0.1
     # via -r requirements-dev.in
 psycopg2-binary==2.9.9
     # via -r requirements.txt


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.

See also https://github.com/PyCQA/docformatter/issues/289