### PR TITLE
Fixing log message and typo in var name

### DIFF
--- a/_helpers/task_executer_service.py
+++ b/_helpers/task_executer_service.py
@@ -13,20 +13,20 @@ class AssessmentTaskExecutorService(TaskExecutorService):
         current_thread = threading.current_thread()
         thread_id = f"[{current_thread.name}:{current_thread.ident}]"
         self.logger.info(f"[{thread_id}] Notification Triggered")
-        massage_id = message["sqs"]["MessageId"]
+        message_id = message["sqs"]["MessageId"]
         try:
             application_json = json.loads(message["s3"])
             application_json_list = []
             fund_round_shortname = "".join(application_json["reference"].split("-")[:2])
             # Check if the import config exists for the application
             if fund_round_shortname not in fund_round_data_key_mappings.keys():
-                self.logger.info.warning(f"Missing import config for the application: {application_json['reference']}.")
+                self.logger.warning(f"Missing import config for the application: {application_json['reference']}.")
                 return message
 
             application_json_list.append(application_json)
             bulk_insert_application_record(application_json_list, is_json=True)
-            self.logger.info(f"{thread_id} Processed the message: {massage_id}")
+            self.logger.info(f"{thread_id} Processed the message: {message_id}")
             return message
 
         except Exception as e:
-            self.logger.error(f"An error occurred while processing the message {massage_id}", e)
+            self.logger.error(f"An error occurred while processing the message {message_id}", e)


### PR DESCRIPTION
Fixing an error in logging a warning, and correcting a variable name