### PR TITLE
BAU: Move application store api host to AWS parameter store secret

### DIFF
--- a/copilot/fsd-assessment-store/manifest.yml
+++ b/copilot/fsd-assessment-store/manifest.yml
@@ -45,7 +45,6 @@ network:
 variables:
   SENTRY_DSN: "https://79a6d9e960144fad834bb3495ecbcc53@o1432034.ingest.sentry.io/4504418765963264"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
-  APPLICATION_STORE_API_HOST: http://fsd-application-store:8080
   ACCOUNT_STORE_API_HOST: http://fsd-account-store:8080
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   AWS_MSG_BUCKET_NAME:
@@ -61,6 +60,7 @@ variables:
 
 secrets:
   FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST
+  APPLICATION_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/APPLICATION_STORE_API_HOST
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
 
 # You can override any of the values defined above by environment.


### PR DESCRIPTION
### Change description
This will help us migrate from the "microservice"-y application-store to a more consolidated pre-award-stores service.

Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-122