### PR TITLE
Allow assessment-store to write to notification queue

### DIFF
--- a/copilot/fsd-assessment-store/addons/notificatio-queue.yml
+++ b/copilot/fsd-assessment-store/addons/notificatio-queue.yml
@@ -1,0 +1,29 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+
+Resources:
+  NotificationQueuePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: NotificationQueuePolicy
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - Fn::ImportValue: !Sub ${App}-${Env}-NotificationQueueArn
+
+Outputs:
+  NotificationQueuePolicyArn:
+    Description: "The ARN of the ManagedPolicy to attach to the task role."
+    Value: !Ref NotificationQueuePolicy


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-110

I missed giving assessment-store write access to the notification queue previously. Somehow this wasn't picked up by tests :(